### PR TITLE
Calculate string lengths only when needed

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -1550,7 +1550,7 @@ jerry_append_number_to_buffer (uint8_t *buffer_p, /**< buffer */
  *         false - otherwise
  */
 static bool
-ecma_string_is_valid_identifier (const ecma_string_t *string_p)
+ecma_string_is_valid_identifier (ecma_string_t *string_p)
 {
   bool result = false;
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -232,8 +232,7 @@ ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
 ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
 ecma_string_t *ecma_append_chars_to_string (ecma_string_t *string1_p,
                                             const lit_utf8_byte_t *cesu8_string2_p,
-                                            lit_utf8_size_t cesu8_string2_size,
-                                            lit_utf8_size_t cesu8_string2_length);
+                                            lit_utf8_size_t cesu8_string2_size);
 ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *string1_p, ecma_string_t *string2_p);
 ecma_string_t *ecma_append_magic_string_to_string (ecma_string_t *string1_p, lit_magic_string_id_t string2_id);
 void ecma_ref_ecma_string (ecma_string_t *string_p);
@@ -246,24 +245,24 @@ ecma_string_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p,
                                   lit_utf8_byte_t *buffer_p,
                                   lit_utf8_size_t buffer_size);
 lit_utf8_size_t JERRY_ATTR_WARN_UNUSED_RESULT
-ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_desc_p,
+ecma_string_copy_to_utf8_buffer (ecma_string_t *string_desc_p,
                                  lit_utf8_byte_t *buffer_p,
                                  lit_utf8_size_t buffer_size);
 lit_utf8_size_t
-ecma_substring_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p,
+ecma_substring_copy_to_cesu8_buffer (ecma_string_t *string_desc_p,
                                      ecma_length_t start_pos,
                                      ecma_length_t end_pos,
                                      lit_utf8_byte_t *buffer_p,
                                      lit_utf8_size_t buffer_size);
 lit_utf8_size_t
-ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p,
+ecma_substring_copy_to_utf8_buffer (ecma_string_t *string_desc_p,
                                     ecma_length_t start_pos,
                                     ecma_length_t end_pos,
                                     lit_utf8_byte_t *buffer_p,
                                     lit_utf8_size_t buffer_size);
 void ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, lit_utf8_byte_t *buffer_p,
                                 lit_utf8_size_t buffer_size);
-const lit_utf8_byte_t *ecma_string_get_chars (const ecma_string_t *string_p, lit_utf8_size_t *size_p, uint8_t *flags_p);
+const lit_utf8_byte_t *ecma_string_get_chars (ecma_string_t *string_p, lit_utf8_size_t *size_p, uint8_t *flags_p);
 bool ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, lit_magic_string_id_t id);
 bool ecma_string_is_empty (const ecma_string_t *string_p);
 bool ecma_string_is_length (const ecma_string_t *string_p);
@@ -278,17 +277,17 @@ bool ecma_string_compare_to_property_name (ecma_property_t property, jmem_cpoint
 bool ecma_compare_ecma_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
 bool ecma_compare_ecma_non_direct_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
 bool ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
-ecma_length_t ecma_string_get_length (const ecma_string_t *string_p);
-ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *string_p);
+ecma_length_t ecma_string_get_length (ecma_string_t *string_p);
+ecma_length_t ecma_string_get_utf8_length (ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_size (const ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *string_p);
-ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *string_p, ecma_length_t index);
+ecma_char_t ecma_string_get_char_at_pos (ecma_string_t *string_p, ecma_length_t index);
 
 lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *string_p);
 
 lit_string_hash_t ecma_string_hash (const ecma_string_t *string_p);
-ecma_string_t *ecma_string_substr (const ecma_string_t *string_p, ecma_length_t start_pos, ecma_length_t end_pos);
-ecma_string_t *ecma_string_trim (const ecma_string_t *string_p);
+ecma_string_t *ecma_string_substr (ecma_string_t *string_p, ecma_length_t start_pos, ecma_length_t end_pos);
+ecma_string_t *ecma_string_trim (ecma_string_t *string_p);
 
 /* ecma-helpers-number.c */
 ecma_number_t ecma_number_make_nan (void);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -172,12 +172,12 @@ ecma_builtin_helper_json_create_formatted_json (lit_utf8_byte_t left_bracket, /*
   ecma_deref_ecma_string (properties_str_p);
 
   chars[0] = LIT_CHAR_LF;
-  final_str_p = ecma_append_chars_to_string (final_str_p, chars, 1, 1);
+  final_str_p = ecma_append_chars_to_string (final_str_p, chars, 1);
 
   final_str_p = ecma_concat_ecma_strings (final_str_p, stepback_p);
 
   chars[0] = right_bracket;
-  final_str_p = ecma_append_chars_to_string (final_str_p, chars, 1, 1);
+  final_str_p = ecma_append_chars_to_string (final_str_p, chars, 1);
 
   return ecma_make_string_value (final_str_p);
 } /* ecma_builtin_helper_json_create_formatted_json */
@@ -218,7 +218,7 @@ ecma_builtin_helper_json_create_non_formatted_json (lit_utf8_byte_t left_bracket
 
   lit_utf8_byte_t chars[1] = { right_bracket };
 
-  result_str_p = ecma_append_chars_to_string (result_str_p, chars, 1, 1);
+  result_str_p = ecma_append_chars_to_string (result_str_p, chars, 1);
 
   return ecma_make_string_value (result_str_p);
 } /* ecma_builtin_helper_json_create_non_formatted_json */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -851,7 +851,7 @@ ecma_builtin_json_parse (ecma_value_t this_arg, /**< 'this' argument */
                   ecma_op_to_string (arg1),
                   ret_value);
 
-  const ecma_string_t *string_p = ecma_get_string_from_value (string);
+  ecma_string_t *string_p = ecma_get_string_from_value (string);
 
   ECMA_STRING_TO_UTF8_STRING (string_p, str_start_p, string_size);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -382,7 +382,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     }
 
     lit_utf8_size_t size = (lit_utf8_size_t) (flags_p - flags);
-    output_str_p = ecma_append_chars_to_string (output_str_p, flags, size, size);
+    output_str_p = ecma_append_chars_to_string (output_str_p, flags, size);
 
     ret_value = ecma_make_string_value (output_str_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1501,7 +1501,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
         ECMA_FINALIZE (separator_to_string_val);
       }
 
-      const ecma_string_t *this_to_string_p = ecma_get_string_from_value (this_to_string_val);
+      ecma_string_t *this_to_string_p = ecma_get_string_from_value (this_to_string_val);
 
       /* 11. */
       if (ecma_string_is_empty (this_to_string_p) && ecma_is_value_empty (ret_value))

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -275,8 +275,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
 
         error_msg_p = ecma_append_chars_to_string (error_msg_p,
                                                    chars_p,
-                                                   chars_size,
-                                                   lit_utf8_string_length (chars_p, chars_size));
+                                                   chars_size);
       }
 
       /* Convert an argument to string without side effects. */
@@ -315,8 +314,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
 
     error_msg_p = ecma_append_chars_to_string (error_msg_p,
                                                chars_p,
-                                               chars_size,
-                                               lit_utf8_string_length (chars_p, chars_size));
+                                               chars_size);
   }
 
   ecma_object_t *error_obj_p = ecma_new_standard_error_with_message (error_type, error_msg_p);


### PR DESCRIPTION
It is not necessary to calculate the length values for strings on
every operation. This patch aims to improve performance by delaying
the length computations until the value is actually required.
This patch was done in cooperation with Tamás Kéri.

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu