### PR TITLE
Fix JerryScript build with clang-6.0

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3421,16 +3421,17 @@ jerry_create_string_sz (const jerry_char_t *str_p,
 **Summary**
 
 Returns a jerry_value_t RegExp object or an error, if the construction of the object fails.
-Optional flags can be set using [jerry_regexp_flags_t](#jerry_regexp_flags_t);
+Optional flags can be set using [jerry_regexp_flags_t](#jerry_regexp_flags_t).
+These flags can be combined together with the binary OR operator or used on their own as enum values.
 
 **Prototype**
 ```c
 jerry_value_t
-jerry_create_regexp (const jerry_char_t *pattern_p, jerry_regexp_flags_t flags);
+jerry_create_regexp (const jerry_char_t *pattern_p, uint16_t flags);
 ```
 
 - `pattern_p` - the RegExp pattern as a zero-terminated UTF-8 string
-- `flags` - optional flags for the RegExp object
+- `flags` - optional flags for the RegExp object, see [jerry_regexp_flags_t](#jerry_regexp_flags_t)
 - return value - the RegExp object as a `jerry_value_t`
 
 **Example**
@@ -3438,7 +3439,7 @@ jerry_create_regexp (const jerry_char_t *pattern_p, jerry_regexp_flags_t flags);
 ```c
 {
   jerry_char_t pattern_p = "[cgt]gggtaaa|tttaccc[acg]";
-  jerry_regexp_flags_t pattern_flags = JERRY_REGEXP_FLAG_IGNORE_CASE;
+  uint16_t pattern_flags = JERRY_REGEXP_FLAG_IGNORE_CASE;
 
   jerry_value_t regexp = jerry_create_regexp (pattern_p, pattern_flags);
 
@@ -3454,17 +3455,18 @@ jerry_create_regexp (const jerry_char_t *pattern_p, jerry_regexp_flags_t flags);
 **Summary**
 
 Returns a jerry_value_t RegExp object or an error, if the construction of the object fails.
-Optional flags can be set using [jerry_regexp_flags_t](#jerry_regexp_flags_t);
+Optional flags can be set using [jerry_regexp_flags_t](#jerry_regexp_flags_t).
+These flags can be combined together with the binary OR operator or used on their own as enum values.
 
 **Prototype**
 ```c
 jerry_value_t
-jerry_create_regexp_sz (const jerry_char_t *pattern_p, jerry_size_t pattern_size, jerry_regexp_flags_t flags);
+jerry_create_regexp_sz (const jerry_char_t *pattern_p, jerry_size_t pattern_size, uint16_t flags);
 ```
 
 - `pattern_p` - the RegExp pattern as a zero-terminated UTF-8 string
 - `pattern_size` - size of the `pattern`
-- `flags` - optional flags for the RegExp object
+- `flags` - optional flags for the RegExp object, see [jerry_regexp_flags_t](#jerry_regexp_flags_t)
 - return value - the RegExp object as a `jerry_value_t`
 
 **Example**
@@ -3473,7 +3475,7 @@ jerry_create_regexp_sz (const jerry_char_t *pattern_p, jerry_size_t pattern_size
 {
   jerry_char_t pattern_p = "[cgt]gggtaaa|tttaccc[acg]";
   jerry_size_t pattern_size = sizeof (pattern_p) - 1;
-  jerry_regexp_flags_t pattern_flags = JERRY_REGEXP_FLAG_IGNORE_CASE;
+  uint16_t pattern_flags = JERRY_REGEXP_FLAG_IGNORE_CASE;
 
   jerry_value_t regexp = jerry_create_regexp_sz (pattern_p, pattern_size, pattern_flags);
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1500,7 +1500,7 @@ jerry_create_string_sz (const jerry_char_t *str_p, /**< pointer to string */
  */
 jerry_value_t
 jerry_create_regexp (const jerry_char_t *pattern_p, /**< zero-terminated UTF-8 string as RegExp pattern */
-                     jerry_regexp_flags_t flags) /**< optional RegExp flags */
+                     uint16_t flags) /**< optional RegExp flags */
 {
   return jerry_create_regexp_sz (pattern_p, lit_zt_utf8_string_size (pattern_p), flags);
 } /* jerry_create_regexp */
@@ -1513,7 +1513,7 @@ jerry_create_regexp (const jerry_char_t *pattern_p, /**< zero-terminated UTF-8 s
 jerry_value_t
 jerry_create_regexp_sz (const jerry_char_t *pattern_p, /**< zero-terminated UTF-8 string as RegExp pattern */
                         jerry_size_t pattern_size, /**< length of the pattern */
-                        jerry_regexp_flags_t flags) /**< optional RegExp flags */
+                        uint16_t flags) /**< optional RegExp flags */
 {
   jerry_assert_api_available ();
 

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -458,9 +458,8 @@ jerry_value_t jerry_create_number_nan (void);
 jerry_value_t jerry_create_null (void);
 jerry_value_t jerry_create_object (void);
 jerry_value_t jerry_create_promise (void);
-jerry_value_t jerry_create_regexp (const jerry_char_t *pattern, jerry_regexp_flags_t flags);
-jerry_value_t jerry_create_regexp_sz (const jerry_char_t *pattern, jerry_size_t pattern_size,
-                                      jerry_regexp_flags_t flags);
+jerry_value_t jerry_create_regexp (const jerry_char_t *pattern, uint16_t flags);
+jerry_value_t jerry_create_regexp_sz (const jerry_char_t *pattern, jerry_size_t pattern_size, uint16_t flags);
 jerry_value_t jerry_create_string_from_utf8 (const jerry_char_t *str_p);
 jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p, jerry_size_t str_size);
 jerry_value_t jerry_create_string (const jerry_char_t *str_p);

--- a/tests/unit-core/test-regexp.c
+++ b/tests/unit-core/test-regexp.c
@@ -26,7 +26,7 @@ main (void)
   jerry_value_t global_obj_val = jerry_get_global_object ();
 
   jerry_char_t pattern[] = "[^.]+";
-  jerry_regexp_flags_t flags = JERRY_REGEXP_FLAG_GLOBAL | JERRY_REGEXP_FLAG_MULTILINE;
+  uint16_t flags = JERRY_REGEXP_FLAG_GLOBAL | JERRY_REGEXP_FLAG_MULTILINE;
   jerry_value_t regex_obj = jerry_create_regexp (pattern, flags);
   TEST_ASSERT (jerry_value_is_object (regex_obj));
 


### PR DESCRIPTION
Clang-6.0 would throw the following error while building

```
jerryscript/jerry-core/api/jerry.c:1527:71: error: implicit conversion loses integer precision:
      'jerry_regexp_flags_t' to 'uint16_t' (aka 'unsigned short') [-Werror,-Wconversion]
  jerry_value_t ret_val = ecma_op_create_regexp_object (ecma_pattern, flags);
```

This patch fixes the issue.
Also change the `jerry_create_regexp` and `jerry_create_regexp_sz` functions' `flags` parameter to `uint16_t` since the values created with `bitwise inclusive OR` are not part of the enum.


JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu