### PR TITLE
Add realloc function to jmem

### DIFF
--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -106,6 +106,7 @@ void jmem_finalize (void);
 
 void *jmem_heap_alloc_block (const size_t size);
 void *jmem_heap_alloc_block_null_on_error (const size_t size);
+void *jmem_heap_realloc_block (void *ptr, const size_t old_size, const size_t new_size);
 void jmem_heap_free_block (void *ptr, const size_t size);
 
 #ifdef JMEM_STATS


### PR DESCRIPTION
This patch extends jmem functionality by adding a realloc function.
This opens up other paths of optimization which can result in smaller
peak memory usage and faster execution times, due to not having to
duplicate memory when we need to extend blocks.

JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai@inf.u-szeged.hu