### PR TITLE
Add missing error check after vm_op_get_value

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1725,12 +1725,15 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           {
             left_value = ECMA_VALUE_UNDEFINED;
             right_value = ECMA_VALUE_UNDEFINED;
+          }
 
-            if (ECMA_IS_VALUE_ERROR (result))
-            {
-              goto error;
-            }
+          if (ECMA_IS_VALUE_ERROR (result))
+          {
+            goto error;
+          }
 
+          if (opcode < CBC_PRE_INCR)
+          {
             break;
           }
 

--- a/tests/jerry/fail/regression-test-issue-2654.js
+++ b/tests/jerry/fail/regression-test-issue-2654.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+--null.static ? this : [ , ] instanceof true;


### PR DESCRIPTION
This patch fixes #2654.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu