### PR TITLE
Fix super keyword parsing for arrow functions

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -1412,7 +1412,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
     {
       if ((lexer_check_next_character (context_p, LIT_CHAR_DOT)
             || lexer_check_next_character (context_p, LIT_CHAR_LEFT_SQUARE))
-          && context_p->status_flags & (PARSER_CLASS_HAS_SUPER | PARSER_IS_ARROW_FUNCTION))
+          && context_p->status_flags & (PARSER_CLASS_HAS_SUPER))
       {
         if (!LEXER_IS_BINARY_LVALUE_TOKEN (context_p->stack_top_uint8))
         {
@@ -1437,9 +1437,8 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
       }
 
       if (lexer_check_next_character (context_p, LIT_CHAR_LEFT_PAREN)
-          && (context_p->status_flags & PARSER_CLASS_HAS_SUPER)
-          && !(context_p->status_flags & PARSER_CLASS_IMPLICIT_SUPER)
-          && (context_p->status_flags & (PARSER_IS_ARROW_FUNCTION | PARSER_CLASS_CONSTRUCTOR)))
+          && ((context_p->status_flags & PARSER_CLASS_CONSTRUCTOR_SUPER) == PARSER_CLASS_CONSTRUCTOR_SUPER)
+          && !(context_p->status_flags & PARSER_CLASS_IMPLICIT_SUPER))
       {
         parser_emit_cbc_ext (context_p, CBC_EXT_PUSH_CONSTRUCTOR_SUPER);
         break;

--- a/tests/jerry/es2015/regression-test-issue-2657.js
+++ b/tests/jerry/es2015/regression-test-issue-2657.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval ("var Mixin1 = (superclass) => class extends super.lass {};");
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}

--- a/tests/jerry/es2015/regression-test-issue-2664.js
+++ b/tests/jerry/es2015/regression-test-issue-2664.js
@@ -1,0 +1,33 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var mustBeCalled = false;
+
+class C1 {
+  f () {
+    mustBeCalled = true;
+    return function () {};
+  }
+}
+
+class C2 extends C1 {
+  f () {
+    return class extends super.f() {}
+  }
+}
+
+var c = new C2;
+c.f ();
+
+assert (mustBeCalled);


### PR DESCRIPTION
This patch fixes #2657.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu