### PR TITLE
Ensure that ecma_builtin_json_str_helper uses [[DefineOwnProperty]] internal method

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -915,19 +915,15 @@ static ecma_value_t ecma_builtin_json_str_helper (const ecma_value_t arg1, /**< 
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
   ecma_object_t *obj_wrapper_p = ecma_op_create_object_object_noarg ();
   ecma_string_t *empty_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-  ecma_value_t put_comp_val = ecma_op_object_put (obj_wrapper_p,
-                                                  empty_str_p,
-                                                  arg1,
-                                                  false);
+  ecma_value_t put_comp_val = ecma_builtin_helper_def_prop (obj_wrapper_p,
+                                                            empty_str_p,
+                                                            arg1,
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                            false);
 
-  if (ecma_is_value_true (put_comp_val))
-  {
-    ret_value = ecma_builtin_json_str (empty_str_p, obj_wrapper_p, &context);
-  }
-  else
-  {
-    ret_value = ECMA_VALUE_UNDEFINED;
-  }
+  JERRY_ASSERT (ecma_is_value_true (put_comp_val));
+
+  ret_value = ecma_builtin_json_str (empty_str_p, obj_wrapper_p, &context);
 
   ecma_free_value (put_comp_val);
   ecma_deref_ecma_string (empty_str_p);

--- a/tests/jerry/regression-test-issue-2652-2653.js
+++ b/tests/jerry/regression-test-issue-2652-2653.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Object.defineProperty (Object.prototype, "", { 'set' : function () { throw ReferenceError ("") } });
+assert (JSON.stringify () === undefined);
+print (JSON.stringify ());


### PR DESCRIPTION
This patch fixes #2652 and fixes #2653 as well, also reverts #2521.
Related part of the standard ECMAScript v5.1 15.12.3.10.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu