### PR TITLE
Fix ecma_op_resolve_reference_base for super object bound lexical environments

### DIFF
--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -96,12 +96,7 @@ ecma_op_has_binding (ecma_object_t *lex_env_p, /**< lexical environment */
   }
   else
   {
-#ifndef CONFIG_DISABLE_ES2015_CLASS
-    JERRY_ASSERT (lex_env_type == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND
-                  || lex_env_type == ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND);
-#else /* CONFIG_DISABLE_ES2015_CLASS */
     JERRY_ASSERT (lex_env_type == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
-#endif /* !CONFIG_DISABLE_ES2015_CLASS */
 
     ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -48,6 +48,14 @@ ecma_op_resolve_reference_base (ecma_object_t *lex_env_p, /**< starting lexical 
 
   while (lex_env_iter_p != NULL)
   {
+#ifndef CONFIG_DISABLE_ES2015_CLASS
+    if (ecma_get_lex_env_type (lex_env_iter_p) == ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND)
+    {
+      lex_env_iter_p = ecma_get_lex_env_outer_reference (lex_env_iter_p);
+      JERRY_ASSERT (lex_env_iter_p != NULL);
+    }
+#endif /* !CONFIG_DISABLE_ES2015_CLASS */
+
     if (ecma_op_has_binding (lex_env_iter_p, name_p))
     {
       return lex_env_iter_p;

--- a/tests/jerry/es2015/regression-test-issue-2666.js
+++ b/tests/jerry/es2015/regression-test-issue-2666.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C {
+  static D () {
+    return 5;
+  }
+}
+
+class D extends C {}
+
+assert (D.D () === 5);


### PR DESCRIPTION
All `ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND` type lexical environments should return their outer reference during resolving syntactic reference.
This patch fixes #2666.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu