### PR TITLE
Fix super property reference parsing

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -1407,7 +1407,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
             || lexer_check_next_character (context_p, LIT_CHAR_LEFT_SQUARE))
           && context_p->status_flags & (PARSER_CLASS_HAS_SUPER | PARSER_IS_ARROW_FUNCTION))
       {
-        if (!LEXER_IS_BINARY_OP_TOKEN (context_p->stack_top_uint8))
+        if (!LEXER_IS_BINARY_LVALUE_TOKEN (context_p->stack_top_uint8))
         {
           context_p->status_flags |= PARSER_CLASS_SUPER_PROP_REFERENCE;
         }

--- a/tests/jerry/es2015/regression-test-issue-2671.js
+++ b/tests/jerry/es2015/regression-test-issue-2671.js
@@ -1,0 +1,49 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Shape {
+  constructor (id,x,y) {
+    this.id = id;
+    this.x = x;
+    this.y = y;
+  }
+  toString () {
+      return "Shape(" + this.id + ")"
+  }
+}
+class Rectangle extends Shape {
+  constructor (id, x, y, width, height) {
+      super (id, x, y);
+  }
+  toString () {
+      return "Rectangle > " + super.toString ();
+  }
+}
+class Circle extends Shape {
+  constructor (id, x, y, radius) {
+      super (id, x, y);
+  }
+  toString () {
+      return "Circle > " + super.toString ();
+  }
+}
+var shape = new Shape (0, 0, 0);
+var rec = new Rectangle (1, 0, 0, 4, 4);
+var circ = new Circle (2, 0, 0, 4);
+
+assert (Object.keys (shape).toString () === "id,x,y");
+assert (rec.id === 1);
+assert (circ.id === 2);
+assert (rec.toString () === "Rectangle > Shape(1)");
+assert (circ.toString () === "Circle > Shape(2)");


### PR DESCRIPTION
`PARSER_CLASS_SUPER_PROP_REFERENCE` flag should be applied for only binary lvalue tokens.
This patch fixed #2671.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu