### PR TITLE
Increase test coverage: Array.prototype.sort

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1058,7 +1058,7 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   ecma_value_t *ecma_value_p = ecma_collection_iterator_init (array_index_props_p);
 
   /* Count properties with name that is array index less than len */
-  while (ecma_value_p != NULL && ecma_is_value_empty (ret_value))
+  while (ecma_value_p != NULL)
   {
     ecma_string_t *property_name_p = ecma_get_string_from_value (*ecma_value_p);
     ecma_value_p = ecma_collection_iterator_next (ecma_value_p);

--- a/tests/jerry/array-prototype-sort.js
+++ b/tests/jerry/array-prototype-sort.js
@@ -92,3 +92,123 @@ try {
   assert(e.message === "foo");
   assert(e instanceof ReferenceError);
 }
+
+// Checking behavior when this value is undefined
+var obj = { sort : Array.prototype.sort };
+
+try {
+  obj.sort.call(undefined, function () { });
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+// Checking behavior when length's valueOf throws exception
+var len = { };
+Object.defineProperty(len, 'valueOf', { 'get' : function () { throw new ReferenceError ("foo"); } });
+var obj = { sort : Array.prototype.sort, length : len };
+
+try {
+  obj.sort();
+  assert(false);
+} catch (e) {
+  assert(e.message === 'foo');
+  assert(e instanceof ReferenceError);
+}
+
+// Checking behavior when unable to get elements
+var obj = { sort : Array.prototype.sort, length : 2};
+Object.defineProperty(obj, '0', { 'get' : function () { throw new ReferenceError ("foo"); } });
+Object.defineProperty(obj, '1', { 'get' : function () { throw new ReferenceError ("bar"); } });
+
+try {
+  obj.sort();
+  assert(false);
+} catch (e) {
+  assert(e.message === "foo");
+  assert(e instanceof ReferenceError);
+}
+
+// Checking behavior when array is non-extensible while sorting
+var arr = [1, 0];
+
+try {
+  arr.sort(function () { Object.freeze(arr) });
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+// Checking behavior when unable to delete property
+var obj = {sort : Array.prototype.sort, '0' : 2, '1' : 1, length : 4};
+Object.defineProperty(obj, '3', function () {});
+
+try {
+  obj.sort();
+  assert(false);
+}
+catch (e) {
+  assert(e instanceof TypeError);
+}
+
+// Checking behavior when unable to get the last element
+var arr = [1, 2, ];
+Object.defineProperty(arr, '2', { 'get' : function () { throw new ReferenceError ("foo"); } });
+
+try {
+  arr.sort();
+  assert(false);
+}
+catch (e) {
+  assert(e.message === 'foo');
+  assert(e instanceof ReferenceError);
+}
+
+// Checking behavior when lhs_value throws exception at comparefn
+f = function () { throw new ReferenceError('foo'); };
+obj = { 'toString' : f };
+arr = [obj, 1];
+
+try {
+  arr.sort();
+  assert(false);
+}
+catch (e) {
+  assert(e.message === 'foo');
+  assert(e instanceof ReferenceError);
+}
+
+// Checking behavior when rhs_value throws exception at comparefn
+f = function () { throw new ReferenceError('foo'); };
+obj = { 'toString' : f };
+arr = [1, obj];
+
+try {
+  arr.sort();
+  assert(false);
+}
+catch (e) {
+  assert(e.message === 'foo');
+  assert(e instanceof ReferenceError);
+}
+
+// Sorting when array elements are the same string
+arr = ['foo', 'foo'];
+arr.sort();
+
+assert(arr[0] === 'foo');
+assert(arr[1] === 'foo');
+
+// Checking behavior when comparefn's call value cannot be converted to number
+obj = { };
+Object.defineProperty(obj, 'toString', function () { });
+f = function () { return obj };
+arr = [1, 2];
+
+try {
+  arr.sort(f);
+  assert(false);
+}
+catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
Added new test cases to array-prototype-sort.js to improve branch coverage.
Branch coverage:
sort:
     - before: 44/50
     - after:  48/48

sort compare helper:
     - before: 18/24
     - after:  24/24

Also removed an unnecessary condition from the while loop what counts properties
with lower index than len.

JerryScript-DCO-1.0-Signed-off-by: Csaba Repasi repasics@inf.u-szeged.hu