### PR TITLE
Add pkg-config metadata files for libraries

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -269,14 +269,22 @@ target_compile_definitions(${JERRY_CORE_NAME} PUBLIC ${DEFINES_JERRY})
 target_include_directories(${JERRY_CORE_NAME} PUBLIC ${INCLUDE_CORE_PUBLIC})
 target_include_directories(${JERRY_CORE_NAME} PRIVATE ${INCLUDE_CORE_PRIVATE})
 
+set(JERRY_CORE_PKGCONFIG_REQUIRES)
+set(JERRY_CORE_PKGCONFIG_LIBS)
+
 if(JERRY_LIBM)
   target_link_libraries(${JERRY_CORE_NAME} jerry-libm)
+  set(JERRY_CORE_PKGCONFIG_REQUIRES libjerry-libm)
 endif()
 
 separate_arguments(EXTERNAL_LINK_LIBS)
 foreach(EXT_LIB ${EXTERNAL_LINK_LIBS})
   target_link_libraries(${JERRY_CORE_NAME} ${EXT_LIB})
+  set(JERRY_CORE_PKGCONFIG_LIBS "${JERRY_CORE_PKGCONFIG_LIBS} -l${EXT_LIB}")
 endforeach()
 
+configure_file(libjerry-core.pc.in libjerry-core.pc @ONLY)
+
 install(TARGETS ${JERRY_CORE_NAME} DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjerry-core.pc DESTINATION lib/pkgconfig)
 install(DIRECTORY ${INCLUDE_CORE_PUBLIC}/ DESTINATION include)

--- a/jerry-core/libjerry-core.pc.in
+++ b/jerry-core/libjerry-core.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libjerry-core
+Description: JerryScript: lightweight JavaScript engine (core engine library)
+URL: https://github.com/pando-project/jerryscript
+Version: 1.0
+Requires.private: @JERRY_CORE_PKGCONFIG_REQUIRES@ # NOTE: libjerry-port-default* is not added as a required package
+Libs: -L${libdir} -ljerry-core
+Libs.private: @JERRY_CORE_PKGCONFIG_LIBS@
+Cflags: -I${includedir}

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -47,9 +47,15 @@ target_include_directories(${JERRY_EXT_NAME} PRIVATE ${INCLUDE_EXT_PRIVATE})
 target_compile_definitions(${JERRY_EXT_NAME} PUBLIC ${DEFINES_EXT})
 target_link_libraries(${JERRY_EXT_NAME} jerry-core)
 
+set(JERRY_EXT_PKGCONFIG_LIBS)
+
 if(USING_MSVC AND FEATURE_DEBUGGER)
   target_link_libraries(${JERRY_EXT_NAME} ws2_32)
+  set(JERRY_EXT_PKGCONFIG_LIBS -lws2_32)
 endif()
 
+configure_file(libjerry-ext.pc.in libjerry-ext.pc @ONLY)
+
 install(TARGETS ${JERRY_EXT_NAME} DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjerry-ext.pc DESTINATION lib/pkgconfig)
 install(DIRECTORY ${INCLUDE_EXT_PUBLIC}/ DESTINATION include)

--- a/jerry-ext/libjerry-ext.pc.in
+++ b/jerry-ext/libjerry-ext.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libjerry-ext
+Description: JerryScript: lightweight JavaScript engine (extensions library)
+URL: https://github.com/pando-project/jerryscript
+Version: 1.0
+Requires.private: libjerry-core
+Libs: -L${libdir} -ljerry-ext
+Libs.private: @JERRY_EXT_PKGCONFIG_LIBS@
+Cflags: -I${includedir}

--- a/jerry-libm/CMakeLists.txt
+++ b/jerry-libm/CMakeLists.txt
@@ -36,5 +36,8 @@ set_property(TARGET ${JERRY_LIBM_NAME}
 
 target_include_directories(${JERRY_LIBM_NAME} PUBLIC ${INCLUDE_LIBM})
 
+configure_file(libjerry-libm.pc.in libjerry-libm.pc @ONLY)
+
 install(TARGETS ${JERRY_LIBM_NAME} DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjerry-libm.pc DESTINATION lib/pkgconfig)
 install(DIRECTORY ${INCLUDE_LIBM}/ DESTINATION include/jerry-libm)

--- a/jerry-libm/libjerry-libm.pc.in
+++ b/jerry-libm/libjerry-libm.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include/jerry-libm
+
+Name: libjerry-libm
+Description: JerryScript: lightweight JavaScript engine (minimal math library)
+URL: https://github.com/pando-project/jerryscript
+Version: 1.0
+Libs: -L${libdir} -ljerry-libm
+Cflags: -I${includedir}

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -64,5 +64,9 @@ endforeach()
 target_compile_definitions(${JERRY_PORT_DEFAULT_NAME}-minimal PRIVATE DISABLE_EXTRA_API)
 
 # Installation
+configure_file(libjerry-port-default.pc.in libjerry-port-default.pc @ONLY)
+configure_file(libjerry-port-default-minimal.pc.in libjerry-port-default-minimal.pc @ONLY)
+
 install(TARGETS ${JERRY_PORT_DEFAULT_NAME} ${JERRY_PORT_DEFAULT_NAME}-minimal DESTINATION lib)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjerry-port-default.pc ${CMAKE_CURRENT_BINARY_DIR}/libjerry-port-default-minimal.pc DESTINATION lib/pkgconfig)
 install(DIRECTORY ${INCLUDE_PORT_DEFAULT}/ DESTINATION include)

--- a/jerry-port/default/libjerry-port-default-minimal.pc.in
+++ b/jerry-port/default/libjerry-port-default-minimal.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libjerry-port-default-minimal
+Description: JerryScript: lightweight JavaScript engine (default minimal port library)
+URL: https://github.com/pando-project/jerryscript
+Version: 1.0
+Conflicts: libjerry-port-default
+Libs: -L${libdir} -ljerry-port-default-minimal
+Cflags: -I${includedir}

--- a/jerry-port/default/libjerry-port-default.pc.in
+++ b/jerry-port/default/libjerry-port-default.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libjerry-port-default
+Description: JerryScript: lightweight JavaScript engine (default port library)
+URL: https://github.com/pando-project/jerryscript
+Version: 1.0
+Conflicts: libjerry-port-default-minimal
+Libs: -L${libdir} -ljerry-port-default
+Cflags: -I${includedir}


### PR DESCRIPTION
Should core, ext, libm, and/or port libraries be properly installed
on some system, help compilation and linking against them by
providing standard `.pc` files, which can be picked up by
pkg-config.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu