### PR TITLE
Update the debugger to work on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,17 @@ platform:
   - x64
   - Win32
 
+environment:
+  matrix:
+    - FEATURE_DEBUGGER: ON
+    - FEATURE_DEBUGGER: OFF
+
 # Steps of a job.
 init:
   - cmake -version
 before_build:
-  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H.
-  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H.
+  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H. -DFEATURE_DEBUGGER=%FEATURE_DEBUGGER%
+  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H. -DFEATURE_DEBUGGER=%FEATURE_DEBUGGER%
 build:
   project: build\Jerry.sln
   parallel: true

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -47,5 +47,9 @@ target_include_directories(${JERRY_EXT_NAME} PRIVATE ${INCLUDE_EXT_PRIVATE})
 target_compile_definitions(${JERRY_EXT_NAME} PUBLIC ${DEFINES_EXT})
 target_link_libraries(${JERRY_EXT_NAME} jerry-core)
 
+if(USING_MSVC AND FEATURE_DEBUGGER)
+  target_link_libraries(${JERRY_EXT_NAME} ws2_32)
+endif()
+
 install(TARGETS ${JERRY_EXT_NAME} DESTINATION lib)
 install(DIRECTORY ${INCLUDE_EXT_PUBLIC}/ DESTINATION include)

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -19,11 +19,13 @@
 #define _XOPEN_SOURCE 500
 #endif
 
-#ifdef HAVE_TIME_H
+#ifdef WIN32
+#include <windows.h>
+#elif defined (HAVE_TIME_H)
 #include <time.h>
 #elif defined (HAVE_UNISTD_H)
 #include <unistd.h>
-#endif /* HAVE_TIME_H */
+#endif /* WIN32 */
 
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
@@ -34,7 +36,9 @@
  */
 void jerry_port_sleep (uint32_t sleep_time) /**< milliseconds to sleep */
 {
-#ifdef HAVE_TIME_H
+#ifdef WIN32
+  Sleep (sleep_time);
+#elif defined (HAVE_TIME_H)
   struct timespec sleep_timespec;
   sleep_timespec.tv_sec = (time_t) sleep_time / 1000;
   sleep_timespec.tv_nsec = ((long int) sleep_time % 1000) * 1000000L;

--- a/jerry-port/default/default-io.c
+++ b/jerry-port/default/default-io.c
@@ -87,7 +87,7 @@ jerry_port_log (jerry_log_level_t level, /**< message log level */
     va_end (args);
     va_start (args, format);
 
-    char buffer[length + 1];
+    JERRY_VLA (char, buffer, length + 1);
     vsnprintf (buffer, (size_t) length + 1, format, args);
 
     fprintf (stderr, "%s", buffer);


### PR DESCRIPTION
Changed the debugger-tcp.c file to include Windows specific
socket handling code.

Added appveyor configuration to build with and without debugger.