### PR TITLE
Inner classes should not finalize the parent's class heritage environment

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -98,11 +98,12 @@ typedef enum
   ECMA_PARSE_NO_OPTS = 0, /**< no options passed */
   ECMA_PARSE_STRICT_MODE = (1u << 0), /**< enable strict mode */
   ECMA_PARSE_DIRECT_EVAL = (1u << 1), /**< eval is called directly (ECMA-262 v5, 15.1.2.1.1) */
-  /* These three status flags must be in this order. See PARSER_CLASS_PARSE_OPTS_OFFSET. */
+  /* These four status flags must be in this order. See PARSER_CLASS_PARSE_OPTS_OFFSET. */
   ECMA_PARSE_CLASS_CONSTRUCTOR = (1u << 2), /**< a class constructor is being parsed (this value must be kept in
                                              *   in sync with PARSER_CLASS_CONSTRUCTOR) */
   ECMA_PARSE_HAS_SUPER = (1u << 3), /**< the current context has super reference */
-  ECMA_PARSE_HAS_STATIC_SUPER = (1u << 4), /**< the current context is a static class method */
+  ECMA_PARSE_HAS_IMPL_SUPER = (1u << 4), /**< the current context has implicit parent class */
+  ECMA_PARSE_HAS_STATIC_SUPER = (1u << 5), /**< the current context is a static class method */
 } ecma_parse_opts_t;
 
 /**

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1053,7 +1053,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
       /* Catch the special case when a the class extends value in null
          and the class has no explicit constructor to raise TypeError.*/
       JERRY_ASSERT (!ecma_op_function_has_construct_flag (arguments_list_p));
-      JERRY_ASSERT (ecma_get_object_prototype (func_obj_p) == NULL);
+      JERRY_ASSERT (ecma_get_object_prototype (func_obj_p) == ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE));
 
       ret_value = ecma_raise_type_error (ECMA_ERR_MSG ("Super constructor null is not a constructor."));
       break;

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -67,12 +67,13 @@ typedef enum
   PARSER_ARROW_PARSE_ARGS = (1u << 19),       /**< parse the argument list of an arrow function */
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-  /* These three status flags must be in this order. See PARSER_CLASS_PARSE_OPTS_OFFSET. */
+  /* These four status flags must be in this order. See PARSER_CLASS_PARSE_OPTS_OFFSET. */
   PARSER_CLASS_CONSTRUCTOR = (1u << 20),      /**< a class constructor is parsed (this value must be kept in
                                                *   in sync with ECMA_PARSE_CLASS_CONSTRUCTOR) */
   PARSER_CLASS_HAS_SUPER = (1u << 21),        /**< class has super reference */
-  PARSER_CLASS_STATIC_FUNCTION = (1u << 22),  /**< this function is a static class method */
-  PARSER_CLASS_SUPER_PROP_REFERENCE = (1u << 23),  /**< super property call or assignment */
+  PARSER_CLASS_IMPLICIT_SUPER = (1u << 22),   /**< class has implicit parent class */
+  PARSER_CLASS_STATIC_FUNCTION = (1u << 23),  /**< this function is a static class method */
+  PARSER_CLASS_SUPER_PROP_REFERENCE = (1u << 24),  /**< super property call or assignment */
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 } parser_general_flags_t;
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1328,7 +1328,9 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           if (ecma_is_value_null (super_value))
           {
-            super_class_p = ecma_create_object (NULL, 0, ECMA_OBJECT_TYPE_GENERAL);
+            super_class_p = ecma_create_object (ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE),
+                                                0,
+                                                ECMA_OBJECT_TYPE_GENERAL);
           }
           else
           {
@@ -1533,7 +1535,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           else
           {
             ecma_object_t *super_class_p = ecma_op_resolve_super_reference_value (frame_ctx_p->lex_env_p);
-            *stack_top_p++ = ecma_fast_copy_value (ecma_make_object_value (super_class_p));
+            ecma_ref_object (super_class_p);
+            *stack_top_p++ = ecma_make_object_value (super_class_p);
           }
 
           continue;

--- a/tests/jerry/es2015/class-inheritance-inner-class.js
+++ b/tests/jerry/es2015/class-inheritance-inner-class.js
@@ -1,0 +1,59 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var console = { assert : assert };
+
+class C1 {
+  f () {
+    return 5;
+  }
+}
+
+class C2 extends C1 {
+  f () {
+    assert (super.f () === 5);
+
+    class G {
+      g () {
+        assert (super.f === undefined);
+        assert (super.toString () === "[object Object]");
+        var a = super.valueOf ();
+        try {
+          a ();
+          assert (false);
+        } catch (e) {
+          assert (e instanceof TypeError);
+        }
+      }
+
+      constructor () {
+        // Test to overwrite the current lit-object
+        console.assert (Object.getPrototypeOf (this) === G.prototype);
+
+        try {
+          eval ("super ()");
+          assert (false);
+        } catch (e) {
+          assert (e instanceof SyntaxError);
+        }
+      }
+    }
+
+    var g = new G ();
+    g.g ();
+  }
+}
+
+(new C2).f ();


### PR DESCRIPTION
This patch is the proper fix for #2667, since #2269 did not fix the problem entirely.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu