### PR TITLE
Normalize routine's arguments before dispatch

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -579,13 +579,10 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
 
   if (builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_TIME)
   {
-    ecma_value_t time = (arguments_number >= 1 ? arguments_list[0]
-                                               : ECMA_VALUE_UNDEFINED);
-
     ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 
     /* 1. */
-    ECMA_OP_TO_NUMBER_TRY_CATCH (time_num, time, ret_value);
+    ECMA_OP_TO_NUMBER_TRY_CATCH (time_num, arguments_list[0], ret_value);
     *prim_value_p = ecma_date_time_clip (time_num);
 
     ret_value = ecma_make_number_value (time_num);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -172,8 +172,7 @@ DISPATCH_ROUTINE_ROUTINE_NAME (uint16_t builtin_routine_id, /**< built-in wide r
 
   switch (builtin_routine_id)
   {
-#define ROUTINE_ARG(n) (arguments_number >= n ? arguments_list[n - 1] \
-                                              : ECMA_VALUE_UNDEFINED)
+#define ROUTINE_ARG(n) (arguments_list[n - 1])
 #define ROUTINE_ARG_LIST_0
 #define ROUTINE_ARG_LIST_1 , ROUTINE_ARG(1)
 #define ROUTINE_ARG_LIST_2 ROUTINE_ARG_LIST_1, ROUTINE_ARG(2)

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -949,6 +949,32 @@ ecma_builtin_dispatch_routine (ecma_builtin_id_t builtin_object_id, /**< built-i
                                ecma_length_t arguments_list_len) /**< length of arguments' list */
 {
   JERRY_ASSERT (builtin_object_id < ECMA_BUILTIN_ID__COUNT);
+
+  ecma_value_t padded_arguments_list_p[3] = { ECMA_VALUE_UNDEFINED, ECMA_VALUE_UNDEFINED, ECMA_VALUE_UNDEFINED };
+
+  if (arguments_list_len <= 2)
+  {
+    switch (arguments_list_len)
+    {
+      case 2:
+      {
+        padded_arguments_list_p[1] = arguments_list_p[1];
+        /* FALLTHRU */
+      }
+      case 1:
+      {
+        padded_arguments_list_p[0] = arguments_list_p[0];
+        break;
+      }
+      default:
+      {
+        JERRY_ASSERT (arguments_list_len == 0);
+      }
+    }
+
+    arguments_list_p = padded_arguments_list_p;
+  }
+
   return ecma_builtin_routines[builtin_object_id] (builtin_routine_id,
                                                    this_arg_value,
                                                    arguments_list_p,


### PR DESCRIPTION
Binary size gain:
 - Intel: ~860B (gcc-7.3)
 - Arm: ~660B (arm-linux-gnueabi-gcc-7.3)

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu