### PR TITLE
Bump Mbed target to Mbed OS 5.11.1

### DIFF
--- a/targets/mbedos5/Makefile.travis
+++ b/targets/mbedos5/Makefile.travis
@@ -25,15 +25,15 @@ all:
 install:
 	pip install mbed-cli
 	cd targets/mbedos5 && mbed deploy
-	pip install intervaltree==2.1.0 # FIXME: workaround until chaimleib/intervaltree#77 is fixed
+	pip install idna==2.5 # FIXME: workaround
 	pip install -r targets/mbedos5/mbed-os/requirements.txt
+	pip install -r targets/mbedos5/tools/requirements.txt
 
 
 ## Targets for building Mbed OS 5 with JerryScript.
 
 # Build the firmware (Mbed OS 5 with JerryScript).
 script:
-	pip install -r targets/mbedos5/tools/requirements.txt
 	# HACK: `EXTRA_SRC[_MOD]` are abused to pass `--library` to `mbed compile` in the `all` make target that builds an app
 	# HACK: this is needed because the Mbed OS 5 target code does not contain any `main` function, so the `all` make target does not link
 	# HACK: but the `library` make target does not build either because the launcher sources require `jerry-targetjs.h` that are explicitly not generated for libraries

--- a/targets/mbedos5/mbed-os.lib
+++ b/targets/mbedos5/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474
+https://github.com/ARMmbed/mbed-os/#c966348d3f9ca80843be7cdc9b748f06ea73ced0


### PR DESCRIPTION
The git hash mbed-os.lib was pointing to marked Mbed OS 5.5.5 and
was more than a year old and more than 10.000 commits behind latest
mbed-os master.

This commit forwards the reference to the latest Mbed OS release
(5.11.1).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu