### PR TITLE
Bump NuttX RTOS target to 7.27

### DIFF
--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -54,7 +54,7 @@ updateobjs:
 cleanlibs: updateobjs
 	rm -f $(OBJS)
 
-clean: cleanlibs
+clean:: cleanlibs
 
 .built: $(LIBS) updateobjs
 

--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -39,8 +39,8 @@ install-kconfig:
 
 # Fetch nuttx/{apps,nuttx} repositories.
 install-clone-nuttx:
-	git clone https://bitbucket.org/nuttx/apps.git ../apps -b nuttx-7.22
-	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b nuttx-7.22
+	git clone https://bitbucket.org/nuttx/apps.git ../apps -b nuttx-7.27
+	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b nuttx-7.27
 
 # Perform all the necessary (JerryScript-independent) installation steps.
 install-noapt: install-kconfig install-clone-nuttx

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -7,16 +7,16 @@ This folder contains files to run JerryScript on
 
 #### 1. Setup the build environment for STM32F4-Discovery board
 
-Clone the necessary projects into a `jerry-nuttx` directory. The last tested working version of NuttX is 7.22.
+Clone the necessary projects into a `jerry-nuttx` directory. The last tested working version of NuttX is 7.27.
 
 ```sh
 # Create a base folder for all the projects.
 mkdir jerry-nuttx && cd jerry-nuttx
 
 git clone https://github.com/pando-project/jerryscript.git
-git clone https://bitbucket.org/nuttx/nuttx.git -b nuttx-7.22
-git clone https://bitbucket.org/nuttx/apps.git -b nuttx-7.22
-git clone https://github.com/texane/stlink.git
+git clone https://bitbucket.org/nuttx/nuttx.git -b nuttx-7.27
+git clone https://bitbucket.org/nuttx/apps.git -b nuttx-7.27
+git clone https://github.com/texane/stlink.git -b v1.5.1
 ```
 
 The following directory structure is created after these commands:


### PR DESCRIPTION
Both documentation and travis makefile were referring to NuttX 7.22,
which was released in Sep 2017. This commit bumps the version to the
latest release (7.27, from Nov 2018).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu