### PR TITLE
Bump ESP8266 target to SDK v2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,12 +122,11 @@ matrix:
           - '${HOME}/.sonar/cache'
 
     - name: "ESP8266 Build Test"
-      cache: ccache
       install: make -f ./targets/esp8266/Makefile.travis install-noapt
       script: make -f ./targets/esp8266/Makefile.travis script
       addons:
         apt:
-          packages: [gperf, texinfo, wget]
+          packages: [wget]
 
     - name: "Mbed OS 5/K64F Build Test"
       addons:

--- a/targets/esp8266/Makefile
+++ b/targets/esp8266/Makefile
@@ -50,7 +50,7 @@ LDDIR = $(SDK_PATH)/ld
 # 	so we use it instead of the original one from SDK.
 JERRY_LD_FILE = $(CURDIR)/ld/eagle.app.v6.ld
 
-CCFLAGS += -Os
+CCFLAGS += -Os -std=c99
 #CCFLAGS += -O0
 
 TARGET_LDFLAGS =					\
@@ -91,7 +91,6 @@ LINKFLAGS_eagle.app.v6 =				\
 	-llwip						\
 	-ldriver					\
 	-lmain						\
-	-lmesh						\
 	-lmirom						\
 	-lnet80211					\
 	-lnopoll					\

--- a/targets/esp8266/Makefile.esp8266
+++ b/targets/esp8266/Makefile.esp8266
@@ -18,7 +18,7 @@ BUILD_DIR  = build/obj-esp8266
 COPYTARGET = targets/esp8266/libs
 USBDEVICE  ?= /dev/ttyUSB0
 JERRYHEAP  ?= 20
-ESPTOOL    ?= /opt/Espressif/esptool-py/esptool.py
+ESPTOOL    ?= $(ESPTOOL_PATH)/esptool.py
 
 # compile flags
 ESP_CFLAGS := -D__TARGET_ESP8266 -D__attr_always_inline___=

--- a/targets/esp8266/Makefile.travis
+++ b/targets/esp8266/Makefile.travis
@@ -23,22 +23,16 @@ all:
 
 # Install tools via apt.
 install-apt-get-deps:
-	sudo apt-get install -q -y gperf texinfo wget
+	sudo apt-get install -q -y wget
 
 # Fetch and build crosstool-NG with support for Xtensa.
 install-xtensa-kx106-gcc:
-	git clone https://github.com/jcmvbkbc/crosstool-NG.git ../crosstool-NG -b lx106-g++-1.21.0
-	cd ../crosstool-NG && ./bootstrap
-	cd ../crosstool-NG && ./configure --enable-local
-	$(MAKE) -C ../crosstool-NG --no-print-directory -Rr # HACK: without the command line arguments, make bails out with recursion error
-	cd ../crosstool-NG && ./ct-ng xtensa-lx106-elf
-	cd ../crosstool-NG && ./ct-ng build
+	wget https://dl.espressif.com/dl/xtensa-lx106-elf-linux64-1.22.0-88-gde0bdc1-4.8.5.tar.gz -O ../xtensa-lx106-elf-linux64-1.22.0-88-gde0bdc1-4.8.5.tar.gz
+	cd .. && tar xvfz xtensa-lx106-elf-linux64-1.22.0-88-gde0bdc1-4.8.5.tar.gz
 
 # Fetch Espressif SDK and Xtensa libraries.
 install-espressif-sdk:
-	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git ../ESP8266_SDK
-	cd ../ESP8266_SDK && git checkout 2fab9e23d779cdd6e5900b8ba2b588e30d9b08c4
-	wget https://github.com/esp8266/esp8266-wiki/raw/master/libs/libhal.a -O ../ESP8266_SDK/lib/libhal.a
+	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git ../ESP8266_RTOS_SDK -b v2.1.0
 
 # Perform all the necessary (JerryScript-independent) installation steps.
 install-noapt: install-xtensa-kx106-gcc install-espressif-sdk
@@ -49,4 +43,4 @@ install: install-apt-get-deps install-noapt
 
 # Build the firmware (ESP8266 with JerryScript).
 script:
-	PATH=$(CURDIR)/../crosstool-NG/builds/xtensa-lx106-elf/bin:$$PATH $(MAKE) -f ./targets/esp8266/Makefile.esp8266 BIN_PATH=build/obj-esp8266 SDK_PATH=$(CURDIR)/../ESP8266_SDK
+	PATH=$(CURDIR)/../xtensa-lx106-elf/bin:$$PATH $(MAKE) -f ./targets/esp8266/Makefile.esp8266 BIN_PATH=build/obj-esp8266 SDK_PATH=$(CURDIR)/../ESP8266_RTOS_SDK

--- a/targets/esp8266/docs/ESP-PREREQUISITES.md
+++ b/targets/esp8266/docs/ESP-PREREQUISITES.md
@@ -9,84 +9,58 @@ You need,
   * 5V 2A adaptor
 * USB to RS-232 Serial + RS-232 Serial to Digital or USB-to-RS232 TTL converter
 
-#### Toolchain
+#### Tools
 
-Reference [Toolchain](https://github.com/esp8266/esp8266-wiki/wiki/Toolchain) page.
-
-I've slightly changed the step to use SDK from Espressif official SDK
-(https://github.com/espressif/esp_iot_rtos_sdk)
-
-##### Toolchain:
-
-dependencies
-```
-sudo apt-get install git autoconf build-essential gperf \
-    bison flex texinfo libtool libtool-bin libncurses5-dev wget \
-    gawk python-serial libexpat-dev
-sudo mkdir /opt/Espressif
-sudo chown $USER /opt/Espressif/
+The rest of this document will assume that you download all necessary tools into
+a common directory structure. For the sake of simplicity, `$HOME/Espressif` will
+be used as the root of this structure. Feel free to deviate from this but then
+adapt all the paths accordingly.
 
 ```
-
-dependency specific to x86:
-```
-sudo apt-get install libc6-dev-i386
+mkdir $HOME/Espressif
 ```
 
-dependency specific to x64:
-```
-sudo apt-get install libc6-dev-amd64
-```
+##### Toolchain
 
-crosstool-NG
+Download the [toolchain](https://github.com/espressif/ESP8266_RTOS_SDK/tree/v3.0.1#get-toolchain)
+pre-built for your development platform to `$HOME/Espressif` and untar it. E.g.,
+on Linux/x86-64:
+
 ```
-cd /opt/Espressif
-git clone -b lx106-g++-1.21.0 git://github.com/jcmvbkbc/crosstool-NG.git
-cd crosstool-NG
-./bootstrap && ./configure --prefix=`pwd` && make && make install
-./ct-ng xtensa-lx106-elf
-./ct-ng build
-```
-add path to environment file such as `.profile`
-```
-PATH=$PWD/builds/xtensa-lx106-elf/bin:$PATH
+cd $HOME/Espressif
+tar xvfz xtensa-lx106-elf-linux64-1.22.0-88-gde0bdc1-4.8.5.tar.gz
 ```
 
 ##### Espressif SDK: use Espressif official
 
 ```
-cd /opt/Esprissif
-git clone https://github.com/espressif/ESP8266_RTOS_SDK.git ESP8266_RTOS_SDK.git
-ln -s ESP8266_RTOS_SDK.git ESP8266_SDK
-git checkout -b jerry 2fab9e23d779cdd6e5900b8ba2b588e30d9b08c4
+cd $HOME/Esprissif
+git clone https://github.com/espressif/ESP8266_RTOS_SDK.git -b v2.1.0
 ```
 
-This verison is tested and works properly.
-
-set two environment variables such as in .profile
-```
-export SDK_PATH=/opt/Espressif/ESP8266_SDK
-export BIN_PATH=(to output folder path)
-```
-
-##### Xtensa libraries and headers:
-```
-cd /opt/Espressif/ESP8266_SDK
-wget -O lib/libhal.a https://github.com/esp8266/esp8266-wiki/raw/master/libs/libhal.a
-```
+This version is tested and works properly.
 
 ##### ESP image tool
 ```
-cd /opt/Espressif
+cd $HOME/Espressif
 wget -O esptool_0.0.2-1_i386.deb https://github.com/esp8266/esp8266-wiki/raw/master/deb/esptool_0.0.2-1_i386.deb
 sudo dpkg -i esptool_0.0.2-1_i386.deb
 ```
 
 ##### ESP upload tool
 ```
-cd /opt/Espressif
-git clone https://github.com/themadinventor/esptool esptool-py
-sudo ln -s $PWD/esptool-py/esptool.py crosstool-NG/builds/xtensa-lx106-elf/bin/esptool.py
+cd $HOME/Espressif
+git clone https://github.com/themadinventor/esptool
+```
+
+##### Set environment variables
+
+Set environment variables, might also go in your `.profile`:
+```
+export PATH=$HOME/Espressif/xtensa-lx106-elf/bin:$PATH
+export SDK_PATH=$HOME/Espressif/ESP8266_RTOS_SDK
+export ESPTOOL_PATH=$HOME/Espressif/esptool
+export BIN_PATH=(to output folder path)
 ```
 
 #### Test writing with Blinky example
@@ -122,7 +96,7 @@ make BOOT=new APP=0 SPI_SPEED=80 SPI_MODE=QIO SPI_SIZE_MAP=2
 * write
 
 ```
-sudo /opt/Espressif/esptool-py/esptool.py \
+sudo $HOME/Espressif/esptool/esptool.py \
   --port /dev/ttyUSB0 write_flash \
   0x00000 $SDK_PATH/bin/"boot_v1.7.bin" \
   0x01000 $BIN_PATH/upgrade/user1.2048.new.5.bin \
@@ -135,7 +109,7 @@ _change `/dev/ttyUSB1` to whatever you have._
 or the old way...this works not sure this is ok.
 ```
 cd $BIN_PATH
-sudo /opt/Espressif/esptool-py/esptool.py \
+sudo $HOME/Espressif/esptool/esptool.py \
 --port /dev/ttyUSB0 write_flash \
 0x00000 eagle.flash.bin 0x40000 eagle.irom0text.bin
 ```


### PR DESCRIPTION
Until now, the ESP8266 target used a non-tagged git hash revision
of the RTOS SDK (from Oct 2017). Moreover, the compiler was also a
custom-built gcc.

This commit sets the RTOS SDK version to v2.1.0, released Oct 2018,
which is the latest old-style SDK for ESP. The commit also changes
the used gcc to an Espressif-provided pre-built toolchain, which is
tagged for the (latest) v3.0.1 SDK release.

(The SDK bump is not to the latest SDK version because the new
v3.x line of the SDK is "ESP-IDF style", which is incompatible with
the current target code base. On the other hand, the toolchain
comes from the latest SDK release because the v2.x line had no
pre-built toolchain suggestions -- but it builds v2.x sources
correctly.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu