### PR TITLE
Fix %TypedArray% object instances symbol properties

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -141,6 +141,13 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
       /* ES2015 9.4.5.1 */
       if (ecma_is_typedarray (ecma_make_object_value (object_p)))
       {
+#ifndef CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN
+        if (ecma_prop_name_is_symbol (property_name_p))
+        {
+          break;
+        }
+#endif /* !CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN */
+
         uint32_t array_index = ecma_string_get_array_index (property_name_p);
 
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)
@@ -476,6 +483,13 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
       /* ES2015 9.4.5.4 */
       if (ecma_is_typedarray (ecma_make_object_value (object_p)))
       {
+#ifndef CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN
+        if (ecma_prop_name_is_symbol (property_name_p))
+        {
+          break;
+        }
+#endif /* !CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN */
+
         uint32_t array_index = ecma_string_get_array_index (property_name_p);
 
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)
@@ -800,6 +814,13 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
       /* ES2015 9.4.5.5 */
       if (ecma_is_typedarray (ecma_make_object_value (object_p)))
       {
+#ifndef CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN
+        if (ecma_prop_name_is_symbol (property_name_p))
+        {
+          break;
+        }
+#endif /* !CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN */
+
         uint32_t array_index = ecma_string_get_array_index (property_name_p);
 
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)
@@ -1148,6 +1169,15 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
       /* ES2015 9.4.5.3 */
       if (ecma_is_typedarray (ecma_make_object_value (obj_p)))
       {
+#ifndef CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN
+        if (ecma_prop_name_is_symbol (property_name_p))
+        {
+          return ecma_op_general_object_define_own_property (obj_p,
+                                                             property_name_p,
+                                                             property_desc_p,
+                                                             is_throw);
+        }
+#endif /* !CONFIG_DISABLE_ES2015_SYMBOL_BUILTIN */
         uint32_t array_index = ecma_string_get_array_index (property_name_p);
 
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)

--- a/tests/jerry/es2015/typedarray-symbol-properties.js
+++ b/tests/jerry/es2015/typedarray-symbol-properties.js
@@ -1,0 +1,35 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var typedArrayTypes = [Int8Array,
+                       Uint8Array,
+                       Uint8ClampedArray,
+                       Int16Array,
+                       Uint16Array,
+                       Int32Array,
+                       Uint32Array,
+                       Float32Array,
+                       Float64Array];
+
+typedArrayTypes.forEach (function (typedArrayType) {
+  var typedArray = new typedArrayType ();
+  var fooSymbol = Symbol ("foo");
+  var barSymbol = Symbol ("bar");
+  typedArray[fooSymbol] = 5;
+  assert (typedArray[fooSymbol] === 5);
+
+  Object.defineProperty (typedArray, barSymbol, {value: 10});
+  assert (typedArray[barSymbol] === 10);
+});


### PR DESCRIPTION
Add missing check for during property handling for %TypedArray% object since until now only string property names were possible.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu