### PR TITLE
Fix out-of-bounds writes (buffer overflows) in unit tests

### DIFF
--- a/tests/unit-core/test-api-strings.c
+++ b/tests/unit-core/test-api-strings.c
@@ -238,9 +238,10 @@ main (void)
   TEST_ASSERT (cesu8_length == 15);
   TEST_ASSERT (cesu8_length == cesu8_sz);
 
-  sz = jerry_substring_to_char_buffer (args[0], 0, cesu8_length, (jerry_char_t *) substring, cesu8_sz);
-  TEST_ASSERT (sz = 15);
-  TEST_ASSERT (!strncmp (substring, "an ascii string", sz));
+  char fullstring[cesu8_sz];
+  sz = jerry_substring_to_char_buffer (args[0], 0, cesu8_length, (jerry_char_t *) fullstring, cesu8_sz);
+  TEST_ASSERT (sz == 15);
+  TEST_ASSERT (!strncmp (fullstring, "an ascii string", sz));
 
   jerry_release_value (args[0]);
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -878,8 +878,8 @@ main (void)
     jerry_release_value (has_prop_js);
     jerry_value_t parsed_data = jerry_get_property (parsed_json, key);
     TEST_ASSERT (jerry_value_is_string (parsed_data)== true);
-    char buff[jerry_get_string_length (parsed_data)];
     jerry_size_t buff_size = (jerry_size_t) jerry_get_string_length (parsed_data);
+    char buff[buff_size + 1];
     jerry_string_to_char_buffer (parsed_data, (jerry_char_t *) buff, buff_size);
     buff[buff_size] = '\0';
     TEST_ASSERT (strcmp (data_check, buff) == false);


### PR DESCRIPTION
Fixes #2711
Fixes #2712

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu