### PR TITLE
Use union to convert between jerryx_arg_int_option_t and uintptr_t

### DIFF
--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -182,8 +182,12 @@ jerryx_arg_helper_process_double (double *d, /**< [in, out] the number to be pro
       return rv; \
     } \
     jerry_release_value (rv); \
-    jerryx_arg_int_option_t *options_p = (jerryx_arg_int_option_t *) &c_arg_p->extra_info; \
-    rv = jerryx_arg_helper_process_double (&tmp, min, max, *options_p); \
+    union \
+    { \
+      jerryx_arg_int_option_t int_option; \
+      uintptr_t extra_info; \
+    } u = { .extra_info = c_arg_p->extra_info }; \
+    rv = jerryx_arg_helper_process_double (&tmp, min, max, u.int_option); \
     if (jerry_value_is_error (rv)) \
     { \
       return rv; \

--- a/jerry-ext/include/jerryscript-ext/arg.impl.h
+++ b/jerry-ext/include/jerryscript-ext/arg.impl.h
@@ -94,12 +94,16 @@ typedef struct
         func = jerryx_arg_transform_ ## type; \
       } \
     } \
-    const jerryx_arg_int_option_t int_option = { .round = (uint8_t) round_flag, .clamp = (uint8_t) clamp_flag }; \
+    union \
+    { \
+      jerryx_arg_int_option_t int_option; \
+      uintptr_t extra_info; \
+    } u = { .int_option = { .round = (uint8_t) round_flag, .clamp = (uint8_t) clamp_flag } }; \
     return (jerryx_arg_t) \
     { \
       .func = func, \
       .dest = (void *) dest, \
-      .extra_info = *(uintptr_t *) &int_option \
+      .extra_info = u.extra_info \
     }; \
   }
 


### PR DESCRIPTION
This fixes potential out-of-bounds reads in jerry-ext when dealing
with integer argument mappings.

Fixes #2713

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu