### PR TITLE
Fix the order of value finalizing in ecma_builtin_typedarray_prototype_join

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1052,9 +1052,9 @@ ecma_builtin_typedarray_prototype_join (ecma_value_t this_arg, /**< this argumen
   }
   ecma_free_value (separator_value);
 
+  ECMA_OP_TO_NUMBER_FINALIZE (length_number);
   ecma_free_value (length_value);
   ecma_free_value (obj_value);
-  ECMA_OP_TO_NUMBER_FINALIZE (length_number);
   return ret_value;
 } /* ecma_builtin_typedarray_prototype_join */
 

--- a/tests/jerry/es2015/regression-test-issue-2724.js
+++ b/tests/jerry/es2015/regression-test-issue-2724.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  var obj = { reverse : Int32Array.prototype.join } ;
+  Object.defineProperty( obj, 'length', { 'get' : function(toPrecision) { return Object.create(/x/); }});
+  obj.reverse("$01$02$11$20");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #2724.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu