### PR TITLE
Add duplicated argument check for function rest parameter

### DIFF
--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -1038,16 +1038,18 @@ parser_error_to_string (parser_error_t error) /**< error code */
     {
       return "Duplicated label.";
     }
-#ifndef CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER
+#if (!defined (CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER) \
+     || !defined (CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER))
     case PARSER_ERR_DUPLICATED_ARGUMENT_NAMES:
     {
       return "Duplicated function argument names are not allowed here.";
     }
-#endif /* !CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER */
+#endif /* (!defined (CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER)
+           || !defined (CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER)) */
 #ifndef CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER
     case PARSER_ERR_FORMAL_PARAM_AFTER_REST_PARAMETER:
     {
-      return "Rest parameter must be last formal parameter.";
+      return "Rest parameter must be the last formal parameter.";
     }
     case PARSER_ERR_REST_PARAMETER_DEFAULT_INITIALIZER:
     {

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2191,6 +2191,12 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
     else if (context_p->token.type == LEXER_THREE_DOTS)
     {
       lexer_expect_identifier (context_p, LEXER_IDENT_LITERAL);
+
+      if (context_p->literal_count == literal_count)
+      {
+        parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
+      }
+
       context_p->status_flags |= PARSER_FUNCTION_HAS_REST_PARAM;
     }
 #endif /* !CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER */

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -119,9 +119,11 @@ typedef enum
   PARSER_ERR_INVALID_RETURN,                          /**< return must be inside a function */
   PARSER_ERR_INVALID_RIGHT_SQUARE,                    /**< right square must terminate a block */
   PARSER_ERR_DUPLICATED_LABEL,                        /**< duplicated label */
-#ifndef CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER
+#if (!defined (CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER) \
+     || !defined (CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER))
   PARSER_ERR_DUPLICATED_ARGUMENT_NAMES,               /**< duplicated argument names */
-#endif /* !CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER */
+#endif /* (!defined (CONFIG_DISABLE_ES2015_FUNCTION_PARAMETER_INITIALIZER)
+           || !defined (CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER)) */
 #ifndef CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER
   PARSER_ERR_FORMAL_PARAM_AFTER_REST_PARAMETER,       /**< formal parameter after rest parameter */
   PARSER_ERR_REST_PARAMETER_DEFAULT_INITIALIZER,      /**< rest parameter default initializer */

--- a/tests/jerry/es2015/function-rest-parameter.js
+++ b/tests/jerry/es2015/function-rest-parameter.js
@@ -33,6 +33,7 @@ function CheckSyntaxError (str)
 CheckSyntaxError ('function x (a, b, ...c, d) {}');
 CheckSyntaxError ('function x (... c = 5) {}');
 CheckSyntaxError ('function x (...) {}');
+CheckSyntaxError ('function x (a, a, ...a) {}');
 CheckSyntaxError ('"use strict" function x (...arguments) {}');
 
 rest_params = ['hello', true, 7, {}, [], function () {}];


### PR DESCRIPTION
Also add a missing word from `PARSER_ERR_FORMAL_PARAM_AFTER_REST_PARAMETER` error message.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu