### PR TITLE
Add new symbol related API functions.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -24,6 +24,7 @@ Enum that contains JerryScript API value types:
  - JERRY_TYPE_OBJECT - object type
  - JERRY_TYPE_FUNCTION - function type
  - JERRY_TYPE_ERROR - error/abort type
+ - JERRY_TYPE_SYMBOL - symbol type
 
 ## jerry_error_t
 
@@ -61,6 +62,7 @@ Possible compile time enabled feature types:
  - JERRY_FEATURE_REGEXP - RegExp support
  - JERRY_FEATURE_LINE_INFO - line info available
  - JERRY_FEATURE_LOGGING - logging
+ - JERRY_FEATURE_SYMBOL - symbol support
 
 ## jerry_regexp_flags_t
 
@@ -1567,6 +1569,57 @@ jerry_value_is_string (const jerry_value_t value)
 - [jerry_release_value](#jerry_release_value)
 
 
+## jerry_value_is_symbol
+
+**Summary**
+
+Returns whether the given `jerry_value_t` is a symbol value.
+
+**Prototype**
+
+```c
+bool
+jerry_value_is_symbol (const jerry_value_t value)
+```
+
+- `value` - API value
+- return value
+  - true, if the given `jerry_value_t` is a symbol
+  - false, otherwise
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t string_value = jerry_create_string ((const jerry_char_t *) "Symbol description string");
+  jerry_value_t symbol_value = jerry_create_symbol (string_value);
+
+  jerry_release_value (string_value);
+
+  if (jerry_value_is_symbol (symbol_value))
+  {
+    // usage of symbol_value
+  }
+
+  jerry_release_value (symbol_value);
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_release_value](#jerry_release_value)
+
+
 ## jerry_value_is_typedarray
 
 **Summary**
@@ -2821,6 +2874,59 @@ jerry_resolve_or_reject_promise (jerry_value_t promise,
 - [jerry_release_value](#jerry_release_value)
 - [jerry_value_is_error](#jerry_value_is_error)
 
+# Functions for symbols
+
+These APIs all depend on the ES2015-subset profile.
+
+## jerry_get_symbol_descriptive_string
+
+**Summary**
+
+Call the SymbolDescriptiveString ecma builtin operation on the API value.
+
+*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_get_symbol_descriptive_string (const jerry_value_t value);
+```
+
+- `value` - symbol value
+- return value
+  - string value containing the symbol's descriptive string - if success
+  - thrown error, otherwise
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t string_value = jerry_create_string ((const jerry_char_t *) "foo");
+  jerry_value_t symbol_value = jerry_create_symbol (string_value);
+
+  jerry_release_value (string_value);
+
+  jerry_value_t symbol_desc_string = jerry_get_symbol_descriptive_string (symbol_value);
+
+  // usage of symbol_desc_string
+
+  jerry_release_value (symbol_desc_string);
+  jerry_release_value (symbol_value);
+
+  jerry_cleanup ();
+}
+```
+
 
 # Acquire and release API values
 
@@ -3544,6 +3650,58 @@ jerry_create_string_sz (const jerry_char_t *str_p,
 
 - [jerry_is_valid_utf8_string](#jerry_is_valid_utf8_string)
 - [jerry_create_string_from_utf8](#jerry_create_string_from_utf8)
+
+
+## jerry_create_symbol
+
+**Summary**
+
+Create symbol from an API value.
+
+*Note*: The given argument is converted to string. This operation can throw an error.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_create_symbol (const jerry_value_t value)
+```
+
+- `value` - API value
+- return value
+  - value of the created symbol, if success
+  - thrown error, otherwise
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t string_value = jerry_create_string ((const jerry_char_t *) "Symbol description string");
+  jerry_value_t symbol_value = jerry_create_symbol (string_value);
+
+  // The description value is no longer needed
+  jerry_release_value (string_value);
+
+  // usage of symbol_value
+
+  jerry_release_value (symbol_value);
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_value_is_symbol](#jerry_value_is_symbol)
+- [jerry_release_value](#jerry_release_value)
 
 
 ## jerry_create_regexp

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -92,6 +92,7 @@ typedef enum
   JERRY_FEATURE_REGEXP, /**< Regexp support */
   JERRY_FEATURE_LINE_INFO, /**< line info available */
   JERRY_FEATURE_LOGGING, /**< logging */
+  JERRY_FEATURE_SYMBOL, /**< symbol support */
   JERRY_FEATURE__COUNT /**< number of features. NOTE: must be at the end of the list */
 } jerry_feature_t;
 
@@ -368,6 +369,7 @@ bool jerry_value_is_null (const jerry_value_t value);
 bool jerry_value_is_object (const jerry_value_t value);
 bool jerry_value_is_promise (const jerry_value_t value);
 bool jerry_value_is_string (const jerry_value_t value);
+bool jerry_value_is_symbol (const jerry_value_t value);
 bool jerry_value_is_undefined (const jerry_value_t value);
 
 /**
@@ -384,6 +386,7 @@ typedef enum
   JERRY_TYPE_OBJECT,    /**< object type */
   JERRY_TYPE_FUNCTION,  /**< function type */
   JERRY_TYPE_ERROR,     /**< error/abort type */
+  JERRY_TYPE_SYMBOL,    /**< symbol type */
 } jerry_type_t;
 
 jerry_type_t jerry_value_get_type (const jerry_value_t value);
@@ -485,6 +488,7 @@ jerry_value_t jerry_create_string_from_utf8 (const jerry_char_t *str_p);
 jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p, jerry_size_t str_size);
 jerry_value_t jerry_create_string (const jerry_char_t *str_p);
 jerry_value_t jerry_create_string_sz (const jerry_char_t *str_p, jerry_size_t str_size);
+jerry_value_t jerry_create_symbol (const jerry_value_t value);
 jerry_value_t jerry_create_undefined (void);
 
 /**
@@ -541,6 +545,11 @@ bool jerry_foreach_object_property (const jerry_value_t obj_val, jerry_object_pr
  * Promise resolve/reject functions.
  */
 jerry_value_t jerry_resolve_or_reject_promise (jerry_value_t promise, jerry_value_t argument, bool is_resolve);
+
+/**
+ * Symbol functions.
+ */
+jerry_value_t jerry_get_symbol_descriptive_string (const jerry_value_t symbol);
 
 /**
  * Input validator functions.

--- a/jerry-ext/handler/handler-print.c
+++ b/jerry-ext/handler/handler-print.c
@@ -50,7 +50,16 @@ jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
 
   for (jerry_length_t arg_index = 0; arg_index < args_cnt; arg_index++)
   {
-    jerry_value_t str_val = jerry_value_to_string (args_p[arg_index]);
+    jerry_value_t str_val;
+
+    if (jerry_value_is_symbol (args_p[arg_index]))
+    {
+      str_val = jerry_get_symbol_descriptive_string (args_p[arg_index]);
+    }
+    else
+    {
+      str_val = jerry_value_to_string (args_p[arg_index]);
+    }
 
     if (jerry_value_is_error (str_val))
     {

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -86,6 +86,19 @@ main (void)
     jerry_release_value (entries[idx].value);
   }
 
+  if (jerry_is_feature_enabled (JERRY_FEATURE_SYMBOL))
+  {
+    jerry_value_t symbol_desc_value = jerry_create_string ((jerry_char_t *) "foo");
+    jerry_value_t symbol_value = jerry_create_symbol (symbol_desc_value);
+    jerry_type_t type_info = jerry_value_get_type (symbol_value);
+
+    TEST_ASSERT (type_info != JERRY_TYPE_NONE);
+    TEST_ASSERT (type_info == JERRY_TYPE_SYMBOL);
+
+    jerry_release_value (symbol_value);
+    jerry_release_value (symbol_desc_value);
+  }
+
   jerry_cleanup ();
 
   return 0;

--- a/tests/unit-core/test-symbol.c
+++ b/tests/unit-core/test-symbol.c
@@ -1,0 +1,197 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "jerryscript-port.h"
+#include "jerryscript-port-default.h"
+#include "test-common.h"
+
+/* foo string */
+#define STRING_FOO ((const jerry_char_t *) "foo")
+
+/* bar string */
+#define STRING_BAR ((const jerry_char_t *) "bar")
+
+/* Symbol(bar) desciptive string */
+#define SYMBOL_DESCIPTIVE_STRING_BAR "Symbol(bar)"
+
+int
+main (void)
+{
+  if (!jerry_is_feature_enabled (JERRY_FEATURE_SYMBOL))
+  {
+    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Symbol support is disabled!\n");
+    return 0;
+  }
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t object = jerry_create_object ();
+
+  /* Test for that each symbol is unique independently from their descriptor strings */
+  jerry_value_t symbol_desc_1 = jerry_create_string (STRING_FOO);
+  jerry_value_t symbol_desc_2 = jerry_create_string (STRING_FOO);
+
+  jerry_value_t symbol_1 = jerry_create_symbol (symbol_desc_1);
+  TEST_ASSERT (!jerry_value_is_error (symbol_1));
+  TEST_ASSERT (jerry_value_is_symbol (symbol_1));
+
+  jerry_value_t symbol_2 = jerry_create_symbol (symbol_desc_2);
+  TEST_ASSERT (!jerry_value_is_error (symbol_2));
+  TEST_ASSERT (jerry_value_is_symbol (symbol_2));
+
+  /* The descriptor strings are no longer needed */
+  jerry_release_value (symbol_desc_1);
+  jerry_release_value (symbol_desc_2);
+
+  jerry_value_t value_1 = jerry_create_number (1);
+  jerry_value_t value_2 = jerry_create_number (2);
+
+  jerry_value_t result_val = jerry_set_property (object, symbol_1, value_1);
+  TEST_ASSERT (jerry_value_is_boolean (result_val));
+  TEST_ASSERT (jerry_get_boolean_value (jerry_has_property (object, symbol_1)));
+  TEST_ASSERT (jerry_get_boolean_value (jerry_has_own_property (object, symbol_1)));
+
+  result_val = jerry_set_property (object, symbol_2, value_2);
+  TEST_ASSERT (jerry_value_is_boolean (result_val));
+  TEST_ASSERT (jerry_get_boolean_value (jerry_has_property (object, symbol_2)));
+  TEST_ASSERT (jerry_get_boolean_value (jerry_has_own_property (object, symbol_2)));
+
+  jerry_value_t get_value_1 = jerry_get_property (object, symbol_1);
+  TEST_ASSERT (jerry_get_number_value (get_value_1) == jerry_get_number_value (value_1));
+  jerry_release_value (get_value_1);
+
+  jerry_value_t get_value_2 = jerry_get_property (object, symbol_2);
+  TEST_ASSERT (jerry_get_number_value (get_value_2) == jerry_get_number_value (value_2));
+  jerry_release_value (get_value_2);
+
+  /* Test delete / has_{own}_property */
+  TEST_ASSERT (jerry_delete_property (object, symbol_1));
+  TEST_ASSERT (!jerry_get_boolean_value (jerry_has_property (object, symbol_1)));
+  TEST_ASSERT (!jerry_get_boolean_value (jerry_has_own_property (object, symbol_1)));
+
+  jerry_release_value (value_1);
+  jerry_release_value (symbol_1);
+
+  /* Test {get, define}_own_property_descriptor */
+  jerry_property_descriptor_t prop_desc;
+  TEST_ASSERT (jerry_get_own_property_descriptor (object, symbol_2, &prop_desc));
+  TEST_ASSERT (prop_desc.is_value_defined == true);
+  TEST_ASSERT (value_2 == prop_desc.value);
+  TEST_ASSERT (jerry_get_number_value (value_2) == jerry_get_number_value (prop_desc.value));
+  TEST_ASSERT (prop_desc.is_writable == true);
+  TEST_ASSERT (prop_desc.is_enumerable == true);
+  TEST_ASSERT (prop_desc.is_configurable == true);
+  TEST_ASSERT (prop_desc.is_get_defined == false);
+  TEST_ASSERT (jerry_value_is_undefined (prop_desc.getter));
+  TEST_ASSERT (prop_desc.is_set_defined == false);
+  TEST_ASSERT (jerry_value_is_undefined (prop_desc.setter));
+  jerry_free_property_descriptor_fields (&prop_desc);
+
+  /* Modify the descriptor fields */
+  jerry_init_property_descriptor_fields (&prop_desc);
+  jerry_value_t value_3 = jerry_create_string (STRING_BAR);
+
+  prop_desc.is_value_defined = true;
+  prop_desc.value = jerry_acquire_value (value_3);
+  prop_desc.is_writable_defined = true;
+  prop_desc.is_writable = false;
+  prop_desc.is_enumerable_defined = true;
+  prop_desc.is_enumerable = false;
+  prop_desc.is_configurable_defined = true;
+  prop_desc.is_configurable = false;
+  TEST_ASSERT (jerry_get_boolean_value (jerry_define_own_property (object, symbol_2, &prop_desc)));
+  jerry_free_property_descriptor_fields (&prop_desc);
+
+  /* Check the modified fields */
+  TEST_ASSERT (jerry_get_own_property_descriptor (object, symbol_2, &prop_desc));
+  TEST_ASSERT (prop_desc.is_value_defined == true);
+  TEST_ASSERT (value_3 == prop_desc.value);
+  TEST_ASSERT (jerry_value_is_string (prop_desc.value));
+  TEST_ASSERT (prop_desc.is_writable_defined == true);
+  TEST_ASSERT (prop_desc.is_writable == false);
+  TEST_ASSERT (prop_desc.is_enumerable_defined == true);
+  TEST_ASSERT (prop_desc.is_enumerable == false);
+  TEST_ASSERT (prop_desc.is_configurable_defined == true);
+  TEST_ASSERT (prop_desc.is_configurable == false);
+  TEST_ASSERT (prop_desc.is_get_defined == false);
+  TEST_ASSERT (jerry_value_is_undefined (prop_desc.getter));
+  TEST_ASSERT (prop_desc.is_set_defined == false);
+  TEST_ASSERT (jerry_value_is_undefined (prop_desc.setter));
+  jerry_free_property_descriptor_fields (&prop_desc);
+
+  jerry_release_value (value_3);
+  jerry_release_value (value_2);
+  jerry_release_value (symbol_2);
+  jerry_release_value (object);
+
+  /* Test creating symbol with a symbol description */
+  jerry_value_t empty_symbol_desc = jerry_create_string ((const jerry_char_t *) "");
+
+  jerry_value_t empty_symbol = jerry_create_symbol (empty_symbol_desc);
+  TEST_ASSERT (!jerry_value_is_error (empty_symbol));
+  TEST_ASSERT (jerry_value_is_symbol (empty_symbol));
+
+  jerry_release_value (empty_symbol_desc);
+
+  jerry_value_t symbol_symbol = jerry_create_symbol (empty_symbol);
+  TEST_ASSERT (!jerry_value_is_symbol (symbol_symbol));
+  TEST_ASSERT (jerry_value_is_error (symbol_symbol));
+
+  jerry_value_t error_obj = jerry_get_value_from_error (symbol_symbol, true);
+
+  TEST_ASSERT (jerry_get_error_type (error_obj) == JERRY_ERROR_TYPE);
+
+  jerry_release_value (error_obj);
+  jerry_release_value (empty_symbol);
+
+  /* Test symbol to string operation with symbol argument */
+  jerry_value_t bar_symbol_desc = jerry_create_string (STRING_BAR);
+
+  jerry_value_t bar_symbol = jerry_create_symbol (bar_symbol_desc);
+  TEST_ASSERT (!jerry_value_is_error (bar_symbol));
+  TEST_ASSERT (jerry_value_is_symbol (bar_symbol));
+
+  jerry_release_value (bar_symbol_desc);
+
+  jerry_value_t bar_symbol_string = jerry_get_symbol_descriptive_string (bar_symbol);
+  TEST_ASSERT (jerry_value_is_string (bar_symbol_string));
+
+  jerry_size_t bar_symbol_string_size = jerry_get_string_size (bar_symbol_string);
+  TEST_ASSERT (bar_symbol_string_size == (sizeof (SYMBOL_DESCIPTIVE_STRING_BAR) - 1));
+  jerry_char_t str_buff[bar_symbol_string_size];
+
+  jerry_string_to_char_buffer (bar_symbol_string, str_buff, bar_symbol_string_size);
+  TEST_ASSERT (memcmp (str_buff, SYMBOL_DESCIPTIVE_STRING_BAR, sizeof (SYMBOL_DESCIPTIVE_STRING_BAR) - 1) == 0);
+
+  jerry_release_value (bar_symbol_string);
+  jerry_release_value (bar_symbol);
+
+  /* Test symbol to string operation with non-symbol argument */
+  jerry_value_t null_value = jerry_create_null ();
+  jerry_value_t to_string_value = jerry_get_symbol_descriptive_string (null_value);
+  TEST_ASSERT (jerry_value_is_error (to_string_value));
+
+  error_obj = jerry_get_value_from_error (to_string_value, true);
+
+  TEST_ASSERT (jerry_get_error_type (error_obj) == JERRY_ERROR_TYPE);
+
+  jerry_release_value (error_obj);
+  jerry_release_value (null_value);
+
+  jerry_cleanup ();
+
+  return 0;
+} /* main */


### PR DESCRIPTION
New functions:
 - ecma_create_symbol
 - ecma_value_is_symbol
 - ecma_get_symbol_descriptive_string

Also improve the `jerryx_handler_print` to be able to print symbol values via using the `ecma_get_symbol_descriptive_string` API function for symbol values.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu