### PR TITLE
Allow build artifacts on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,3 +30,7 @@ build:
   project: build\Jerry.sln
   parallel: true
   verbosity: minimal
+
+artifacts:
+  - path: build\bin\$(configuration)\
+    name: JerryScriptBinary


### PR DESCRIPTION
Enabled the creation of JerryScript Windows binary artifacts during builds.