### PR TITLE
Add missing error checks for ecma_regexp_exec_helper

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1326,10 +1326,15 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     {
       if (re_ctx.flags & RE_FLAG_GLOBAL)
       {
-        ecma_op_object_put (regexp_object_p,
-                            ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
-                            ecma_make_integer_value (0),
-                            true);
+        ecma_value_t put_result = ecma_op_object_put (regexp_object_p,
+                                                      ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
+                                                      ecma_make_integer_value (0),
+                                                      true);
+        if (ECMA_IS_VALUE_ERROR (put_result))
+        {
+          ecma_free_value (ret_value);
+          ret_value = put_result;
+        }
       }
 
       is_match = false;
@@ -1372,10 +1377,16 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       lastindex_num = ECMA_NUMBER_ZERO;
     }
 
-    ecma_op_object_put (regexp_object_p,
-                        ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
-                        ecma_make_number_value (lastindex_num),
-                        true);
+    ecma_value_t put_result = ecma_op_object_put (regexp_object_p,
+                                                  ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
+                                                  ecma_make_number_value (lastindex_num),
+                                                  true);
+
+    if (ECMA_IS_VALUE_ERROR (put_result))
+    {
+      ecma_free_value (ret_value);
+      ret_value = put_result;
+    }
   }
 
   /* 3. Fill the result array or return with 'undefiend' */

--- a/tests/jerry/regression-test-issue-2755.js
+++ b/tests/jerry/regression-test-issue-2755.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  var v0 = Object.freeze (RegExp ($, "g")).exec ();
+  var $ = v0.every (Function ("a1,a2,a3",  "this.shifted=a3+a2+a1.length;"), v0.hasOwnProperty);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #2755.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu