### PR TITLE
Target arraybuffer's buffer should be absolute addressed in ecma_op_typedarray_set_with_typedarray

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -708,7 +708,7 @@ ecma_op_typedarray_set_with_typedarray (ecma_value_t this_arg, /**< this argumen
 
   /* 9. targetBuffer */
   ecma_object_t *target_arraybuffer_p = ecma_typedarray_get_arraybuffer (target_typedarray_p);
-  lit_utf8_byte_t *target_buffer_p = ecma_typedarray_get_buffer (target_typedarray_p);
+  lit_utf8_byte_t *target_buffer_p = ecma_arraybuffer_get_buffer (target_arraybuffer_p);
 
   /* 11. targetLength */
   ecma_length_t target_length = ecma_typedarray_get_length (target_typedarray_p);
@@ -752,6 +752,12 @@ ecma_op_typedarray_set_with_typedarray (ecma_value_t this_arg, /**< this argumen
   if ((int64_t) src_length_uint32 + target_offset_uint32 > target_length)
   {
     return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid range of index"));
+  }
+
+  /* Fast path first. If the source and target arrays are the same we do not need to copy anything. */
+  if (this_arg == arr_val)
+  {
+    return ECMA_VALUE_UNDEFINED;
   }
 
   /* 24.d, 25. srcByteIndex */

--- a/tests/jerry/es2015/regression-test-issue-2757.js
+++ b/tests/jerry/es2015/regression-test-issue-2757.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var v1 = (new Int8Array (149)).subarray (78);
+var v1ToString = v1.toString ();
+v1.set (v1);
+assert (v1ToString === v1.toString ());


### PR DESCRIPTION
This patch fixes #2757, also adds a short path for the case when the source and the target typedarrays are the same.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu