### PR TITLE
Fix JSON.stringify

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1590,8 +1590,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
 
       JERRY_ASSERT (ecma_is_property_enumerable (property));
 
-      if (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA
-          || ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_VIRTUAL)
+      if (ECMA_PROPERTY_GET_TYPE (property) != ECMA_PROPERTY_TYPE_SPECIAL)
       {
         ecma_append_to_values_collection (property_keys_p, *ecma_value_p, 0);
       }

--- a/tests/jerry/es2015/object-assign.js
+++ b/tests/jerry/es2015/object-assign.js
@@ -146,7 +146,7 @@ function completeAssign (target, sources) {
 }
 
 var copy = completeAssign ({}, [obj]);
-assert (JSON.stringify (copy) === '{"foo":1}');
+assert (JSON.stringify (copy) === '{"foo":1,"bar":2}');
 assert (copy.bar === 2);
 
 // Test when target is not coercible to object


### PR DESCRIPTION
There was a wrong check on the property types, it did not check that the
property was a named accessor. Also fixed a test case.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu