### PR TITLE
Builtin Object constructor should handle symbol arguments

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -79,7 +79,7 @@ ecma_op_create_object_object_arg (ecma_value_t value) /**< argument of construct
 
   if (ecma_is_value_object (value)
       || ecma_is_value_number (value)
-      || ecma_is_value_string (value)
+      || ecma_is_value_prop_name (value)
       || ecma_is_value_boolean (value))
   {
     /* 1.b, 1.c, 1.d */

--- a/tests/jerry/es2015/regression-test-issue-2768.js
+++ b/tests/jerry/es2015/regression-test-issue-2768.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (typeof new Object (Symbol ()) === "object");


### PR DESCRIPTION
This patch fixes #2768.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu