### PR TITLE
Ensure that Symbol.toStringTag property is copied to buffer as a cesu8 string

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -78,8 +78,8 @@ ecma_builtin_helper_object_to_string_tag_helper (ecma_value_t tag_value) /**< st
   }
 
   /* Copy to buffer the #@@toStringTag# string */
-  buffer_ptr += ecma_string_copy_to_utf8_buffer (tag_str_p, buffer_ptr,
-                                                 (lit_utf8_size_t) ((str_buffer + buffer_size) - buffer_ptr));
+  buffer_ptr += ecma_string_copy_to_cesu8_buffer (tag_str_p, buffer_ptr,
+                                                  (lit_utf8_size_t) ((str_buffer + buffer_size) - buffer_ptr));
 
   JERRY_ASSERT (buffer_ptr <= str_buffer + buffer_size);
 

--- a/tests/jerry/es2015/regression-test-issue-2769.js
+++ b/tests/jerry/es2015/regression-test-issue-2769.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+delete JSON[Symbol.toStringTag];
+JSON[Symbol.toStringTag ] = "𖠀";
+assert (Map.prototype.toString.call(JSON) === "[object 𖠀]");


### PR DESCRIPTION
This patch fixes #2769.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu