### PR TITLE
Use [[DefineOwnProperty]] in the iterator next step in ecma_builtin_promise_do_all

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -14,6 +14,7 @@
  */
 
 #include "ecma-array-object.h"
+#include "ecma-builtin-helpers.h"
 #include "ecma-exceptions.h"
 #include "ecma-function-object.h"
 #include "ecma-gc.h"
@@ -478,10 +479,11 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
       break;
     }
 
-    ecma_value_t put_ret = ecma_op_object_put (ecma_get_object_from_value (value_array),
-                                               index_to_str_p,
-                                               undefined_val,
-                                               false);
+    ecma_value_t put_ret = ecma_builtin_helper_def_prop (ecma_get_object_from_value (value_array),
+                                                         index_to_str_p,
+                                                         undefined_val,
+                                                         ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                         false);
     ecma_deref_ecma_string (index_to_str_p);
 
     if (ECMA_IS_VALUE_ERROR (put_ret))

--- a/tests/jerry/es2015/regression-test-issue-2770.js
+++ b/tests/jerry/es2015/regression-test-issue-2770.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Object.defineProperty(Array.prototype, 0, {set: function() { return Array.prototype.push(), Object.freeze(Array.prototype)}});
+Promise.all([0]);


### PR DESCRIPTION
This patch fixes #2770.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu