### PR TITLE
Fix the rest parameter behavior if the arguments object needs to be created

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -601,7 +601,18 @@ parser_generate_initializers (parser_context_t *context_p, /**< context */
       }
     }
 
-    JERRY_ASSERT (argument_count == context_p->argument_count);
+#ifndef CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER
+    if (context_p->status_flags & PARSER_FUNCTION_HAS_REST_PARAM)
+    {
+      JERRY_ASSERT ((argument_count - 1) == context_p->argument_count);
+    }
+    else
+    {
+#endif /* !CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER */
+      JERRY_ASSERT (argument_count == context_p->argument_count);
+#ifndef CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER
+    }
+#endif /* !CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER */
   }
 
   parser_list_iterator_init (&context_p->literal_pool, &literal_iterator);
@@ -981,6 +992,13 @@ parse_print_literal (ecma_compiled_code_t *compiled_code_p, /**< compiled code *
     ident_end = args_p->ident_end;
     const_literal_end = args_p->const_literal_end;
   }
+
+#ifndef CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER
+  if (compiled_code_p->status_flags & CBC_CODE_FLAGS_REST_PARAMETER)
+  {
+    argument_end++;
+  }
+#endif /* !CONFIG_DISABLE_ES2015_FUNCTION_REST_PARAMETER */
 
   parser_list_iterator_init (literal_pool_p, &literal_iterator);
 

--- a/tests/jerry/es2015/regression-test-issue-2777.js
+++ b/tests/jerry/es2015/regression-test-issue-2777.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var f = function (a, b, ...argArr0) {
+    arguments;
+    assert (a === 1);
+    assert (b === 2);
+    assert (argArr0.length === 2);
+    assert (argArr0.toString() === "3,4");
+}
+
+f (1,2,3,4);


### PR DESCRIPTION
This patch fixes #2777.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu