### PR TITLE
Fix getting the iterated object's length property

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-iterator-prototype.c
@@ -92,11 +92,26 @@ ecma_builtin_array_iterator_prototype_object_next (ecma_value_t this_val) /**< t
   else
   {
 #endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
-    JERRY_ASSERT (ecma_get_object_type (array_object_p) == ECMA_OBJECT_TYPE_ARRAY);
+    ecma_value_t len_value = ecma_op_object_get (array_object_p,
+                                                 ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH));
 
-    ecma_extended_object_t *ext_array_obj_p = (ecma_extended_object_t *) array_object_p;
+    if (ECMA_IS_VALUE_ERROR (len_value))
+    {
+      return len_value;
+    }
 
-    length = ext_array_obj_p->u.array.length;
+    ecma_number_t length_number;
+    ecma_value_t length_value = ecma_get_number (len_value, &length_number);
+
+    if (ECMA_IS_VALUE_ERROR (length_value))
+    {
+      ecma_free_value (len_value);
+      return length_value;
+    }
+
+    length = ecma_number_to_uint32 (length_number);
+
+    ecma_free_value (len_value);
 #ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
   }
 #endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */

--- a/tests/jerry/es2015/regression-test-issue-2782.js
+++ b/tests/jerry/es2015/regression-test-issue-2782.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arrayLikeObj = { "0" : 0, "1" : 1, "2" : 2, "length": 3 }
+
+iterator = Array.prototype.keys.call (arrayLikeObj);
+
+for (var i = 0; i < arrayLikeObj.length; i++) {
+  var next = iterator.next ();
+  assert (next.value === i && next.done === false);
+}
+
+next = iterator.next ();
+assert (next.done === true);


### PR DESCRIPTION
This patch fixes #2782.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu