### PR TITLE
Fix the vm stop checking bug

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2553,7 +2553,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_are_values_integer_numbers (left_value, right_value))
           {
             bool is_less = (ecma_integer_value_t) left_value < (ecma_integer_value_t) right_value;
-
+#ifndef JERRY_VM_EXEC_STOP
             /* This is a lookahead to the next opcode to improve performance.
              * If it is CBC_BRANCH_IF_TRUE_BACKWARD, execute it. */
             if (*byte_code_p <= CBC_BRANCH_IF_TRUE_BACKWARD_3 && *byte_code_p >= CBC_BRANCH_IF_TRUE_BACKWARD)
@@ -2587,7 +2587,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
               continue;
             }
-
+#endif /* !JERRY_VM_EXEC_STOP */
             *stack_top_p++ = ecma_make_boolean_value (is_less);
             continue;
           }


### PR DESCRIPTION
when the vm executes VM_OC_LESS operation, the lookahead optimization will cause the by-passing of vm stop checking.
Thus we need to disable the optimization here if JERRY_VM_EXEC_STOP is defined.

JerryScript-DCO-1.0-Signed-off-by: Wang Zhikang wzk0406@mail.ustc.edu.cn