### PR TITLE
Fixed 'jerry_get_object_keys' API function.

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2475,7 +2475,8 @@ jerry_get_object_keys (const jerry_value_t obj_val) /**< object value */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (wrong_args_msg_p)));
   }
 
-  return ecma_builtin_helper_object_get_properties (ecma_get_object_from_value (obj_val), true);
+  return ecma_builtin_helper_object_get_properties (ecma_get_object_from_value (obj_val),
+                                                    ECMA_LIST_ENUMERABLE);
 } /* jerry_get_object_keys */
 
 /**

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -650,6 +650,7 @@ main (void)
   res = jerry_get_object_keys (global_obj_val);
   TEST_ASSERT (!jerry_value_is_error (res));
   TEST_ASSERT (jerry_value_is_array (res));
+  TEST_ASSERT (jerry_get_array_length (res) == 15);
   jerry_release_value (res);
 
   /* Test: jerry_value_to_primitive */


### PR DESCRIPTION
'jerry_get_object_keys' always gave back an empty array.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com