### PR TITLE
Run test262 test suite in both release and debug mode on Travis CI.

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -111,13 +111,14 @@ JERRY_TEST_SUITE_OPTIONS.extend([
 
 # Test options for test262
 TEST262_TEST_SUITE_OPTIONS = [
-    Options('test262_tests')
+    Options('test262_tests'),
+    Options('test262_tests-debug', OPTIONS_DEBUG)
 ]
 
 # Test options for jerry-debugger
 DEBUGGER_TEST_OPTIONS = [
     Options('jerry_debugger_tests',
-            ['--debug', '--jerry-debugger=on'])
+            OPTIONS_DEBUG + ['--jerry-debugger=on'])
 ]
 
 # Test options for buildoption-test


### PR DESCRIPTION
The CI ran test262 test suite in release mode only to save time.
This patch enables the debug testing on the test suite, which means
the runtime of the "Conformance Tests" job will increase by a few
minutes.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com