### PR TITLE
Identifiers should be stored in the lexical environment if argument object needs to be created

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -226,7 +226,7 @@ parser_compute_indicies (parser_context_t *context_p, /**< context */
       {
         if (literal_p->status_flags & LEXER_FLAG_VAR)
         {
-          if (status_flags & PARSER_NO_REG_STORE)
+          if (status_flags & (PARSER_NO_REG_STORE | PARSER_ARGUMENTS_NEEDED))
           {
             literal_p->status_flags |= LEXER_FLAG_NO_REG_STORE;
           }

--- a/tests/jerry/regression-test-issue-2699.js
+++ b/tests/jerry/regression-test-issue-2699.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f(a) {
+  function a() {
+    return 5;
+  }
+
+  assert (typeof a === "function");
+  assert (a () === 5);
+  assert (arguments[0] () === 5);
+}
+
+f (6);


### PR DESCRIPTION
This patch fixes #2699.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu