### PR TITLE
Class this binding must be bound to non-heritage contexts as well

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -536,16 +536,14 @@ static ecma_object_t *
 ecma_op_find_super_declerative_lex_env (ecma_object_t *lex_env_p) /**< starting lexical enviroment */
 {
   JERRY_ASSERT (lex_env_p);
-  JERRY_ASSERT (ecma_op_resolve_super_reference_value (lex_env_p));
   JERRY_ASSERT (ecma_get_lex_env_type (lex_env_p) != ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND);
 
-  while (true)
+  while (lex_env_p != NULL)
   {
     ecma_object_t *lex_env_outer_p = ecma_get_lex_env_outer_reference (lex_env_p);
 
-    JERRY_ASSERT (lex_env_outer_p);
-
-    if (ecma_get_lex_env_type (lex_env_outer_p) == ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND)
+    if (lex_env_outer_p != NULL &&
+        ecma_get_lex_env_type (lex_env_outer_p) == ECMA_LEXICAL_ENVIRONMENT_SUPER_OBJECT_BOUND)
     {
       JERRY_ASSERT (ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE);
       return lex_env_p;
@@ -553,6 +551,8 @@ ecma_op_find_super_declerative_lex_env (ecma_object_t *lex_env_p) /**< starting 
 
     lex_env_p = lex_env_outer_p;
   }
+
+  return NULL;
 } /* ecma_op_find_super_declerative_lex_env */
 
 /**
@@ -569,7 +569,8 @@ ecma_op_get_class_this_binding_property (ecma_object_t *lex_env_p) /**< starting
 
   lex_env_p = ecma_op_find_super_declerative_lex_env (lex_env_p);
   ecma_string_t *name_p = ecma_get_magic_string (LIT_INTERNAL_MAGIC_STRING_CLASS_THIS_BINDING);
-  return ecma_find_named_property (lex_env_p, name_p);
+
+  return lex_env_p == NULL ? NULL : ecma_find_named_property (lex_env_p, name_p);
 } /* ecma_op_get_class_this_binding_property */
 
 /**

--- a/tests/jerry/es2015/regression-test-issue-2822.js
+++ b/tests/jerry/es2015/regression-test-issue-2822.js
@@ -1,0 +1,31 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Animal {
+    constructor() {
+        eval();
+    }
+    explain() { }
+}
+class Dog extends Animal {
+    constructor() {
+        super()
+    }
+}
+class Doge extends Dog {
+    whoAmI() {}
+}
+
+var d = new Doge;
+assert (typeof d === "object");


### PR DESCRIPTION
This patch fixes #2822.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu