### PR TITLE
Non-object values should give early false result for instanceof operator

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -402,6 +402,11 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
   JERRY_ASSERT (func_obj_p != NULL
                 && !ecma_is_lexical_environment (func_obj_p));
 
+  if (!ecma_is_value_object (value))
+  {
+    return ECMA_VALUE_FALSE;
+  }
+
   while (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION)
   {
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
@@ -422,11 +427,6 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
 
   JERRY_ASSERT (ecma_is_normal_or_arrow_function (ecma_get_object_type (func_obj_p))
                 || ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
-
-  if (!ecma_is_value_object (value))
-  {
-    return ECMA_VALUE_FALSE;
-  }
 
   ecma_object_t *v_obj_p = ecma_get_object_from_value (value);
 

--- a/tests/jerry/es2015/regression-test-issue-2823.js
+++ b/tests/jerry/es2015/regression-test-issue-2823.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class myArray extends Array {}
+assert (!(undefined instanceof myArray));


### PR DESCRIPTION
This patch fixes #2823.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu