### PR TITLE
Super parse options should be cleared before setting it's value

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1499,6 +1499,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_CLASS_EVAL:
         {
+          ECMA_CLEAR_SUPER_EVAL_PARSER_OPTS ();
           ECMA_SET_SUPER_EVAL_PARSER_OPTS (*byte_code_p++);
           continue;
         }

--- a/tests/jerry/es2015/regression-test-issue-2825.js
+++ b/tests/jerry/es2015/regression-test-issue-2825.js
@@ -1,0 +1,42 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var $;
+var called = false;
+
+function f() {}
+var B = class extends f {
+    constructor() {
+        eval();
+        super($)
+        this.g()
+    }
+}
+C = class extends B {
+    g() {
+        () => {
+          called = true;
+        }()
+    }
+}
+D = class extends C {
+    constructor() {
+        super()
+    }
+    g() {
+        eval('super["g"]')()
+    }
+}
+new D
+assert (called);


### PR DESCRIPTION
This patch fixes #2825.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu