### PR TITLE
Add STM32F7 support

### DIFF
--- a/cmake/toolchain_mcu_stm32f7.cmake
+++ b/cmake/toolchain_mcu_stm32f7.cmake
@@ -1,0 +1,22 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_SYSTEM_NAME MCU)
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
+set(CMAKE_SYSTEM_VERSION STM32F7)
+
+set(FLAGS_COMMON_ARCH -mthumb -mcpu=cortex-m7 -march=armv7e-m -mfloat-abi=hard)
+
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)


### PR DESCRIPTION
It was tested on NucleoF767ZI running current NuttX master branch.

Some flags are not defined because,
they can be deduced from CPU type.

Change-Id: I68c9787fe3003338228f47fbaf3e7a9522bcd6d5
Relate-to: https://github.com/pando-project/libtuv/pull/136
JerryScript-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com