### PR TITLE
undefined byteLength should be treated 0 in DataView constructor

### DIFF
--- a/jerry-core/ecma/operations/ecma-dataview-object.c
+++ b/jerry-core/ecma/operations/ecma-dataview-object.c
@@ -112,7 +112,11 @@ ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments li
 
     int32_t byte_length_int32 = ecma_number_to_int32 (byte_length);
 
-    if (ecma_number_is_infinity (byte_length))
+    if (ecma_number_is_nan (byte_length))
+    {
+      viewByteLength = 0;
+    }
+    else if (ecma_number_is_infinity (byte_length))
     {
       viewByteLength = UINT32_MAX;
     }

--- a/tests/jerry/es2015/regression-test-issue-2854.js
+++ b/tests/jerry/es2015/regression-test-issue-2854.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var buffer = new ArrayBuffer()
+var dataView = new DataView(buffer, 0, undefined)
+
+assert(dataView.byteLength === 0);


### PR DESCRIPTION
This patch fixes #2854.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu