### PR TITLE
Clear top module context after local variables have been imported

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3603,6 +3603,8 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
     {
       return ret_value;
     }
+
+    JERRY_CONTEXT (module_top_context_p) = NULL;
   }
 #endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
 

--- a/tests/jerry/es2015/module-import-04.js
+++ b/tests/jerry/es2015/module-import-04.js
@@ -1,0 +1,16 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "tests/jerry/es2015/module-import-01.js"


### PR DESCRIPTION
This fixes an assertion failure which was caused by incorrectly importing
the same variables multiple times.

Co-authored-by: Marko Fabo <mfabo@inf.u-szeged.hu>
JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Dániel Bátyai dbatyai@inf.u-szeged.hu