### PR TITLE
Super parsing options should be set only in direct eval call

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -27,6 +27,7 @@
 #include "lit-magic-strings.h"
 #include "lit-strings.h"
 #include "vm.h"
+#include "jcontext.h"
 #include "jrt-libc-includes.h"
 #include "jrt-bit-fields.h"
 
@@ -98,6 +99,13 @@ ecma_builtin_global_object_eval (ecma_value_t x) /**< routine's first argument *
     JERRY_ASSERT (parse_opts & ECMA_PARSE_DIRECT_EVAL);
     parse_opts |= ECMA_PARSE_STRICT_MODE;
   }
+
+#if ENABLED (JERRY_ES2015_CLASS)
+  if (vm_is_direct_eval_form_call ())
+  {
+    parse_opts |= ECMA_GET_SUPER_EVAL_PARSER_OPTS ();
+  }
+#endif /* ENABLED (JERRY_ES2015_CLASS) */
 
   /* steps 2 to 8 */
   return ecma_op_eval (ecma_get_string_from_value (x), parse_opts);

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -96,8 +96,6 @@ ecma_op_eval_chars_buffer (const lit_utf8_byte_t *code_p, /**< code characters b
 #endif /* JERRY_ENABLE_LINE_INFO */
 
 #if ENABLED (JERRY_ES2015_CLASS)
-  parse_opts |= ECMA_GET_SUPER_EVAL_PARSER_OPTS ();
-
   ECMA_CLEAR_SUPER_EVAL_PARSER_OPTS ();
 #endif /* ENABLED (JERRY_ES2015_CLASS) */
 

--- a/tests/jerry/fail/regression-test-issue-2846.js
+++ b/tests/jerry/fail/regression-test-issue-2846.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f ( ) { }
+var B = class extends f { constructor ( ){ eval ( "eval ('super (1, 2, 3, 4)')" ) ; } }
+    C = class extends B { g ( ) { { ( ) => { } } } }
+    D = class extends C { constructor ( ) { super ( )
+}
+
+g () { eval () } }
+eval = eval.bind()
+new D


### PR DESCRIPTION
This patch fixes #2846.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu