### PR TITLE
Add missing error check for ecma_regexp_exec_helper

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1362,7 +1362,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     }
   }
 
-  if (input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
+  if (!ECMA_IS_VALUE_ERROR (ret_value) && input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
     ecma_number_t lastindex_num;
 

--- a/tests/jerry/fail/regression-test-issue-2885.js
+++ b/tests/jerry/fail/regression-test-issue-2885.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Object.defineProperties(constructor, { $: Object })
+JSON.parse('{"a":1}', function (k) {
+  if (k) { $ *= $ }
+})
+var $ = Object.freeze(RegExp($, 'g')).exec()


### PR DESCRIPTION
This patch fixes #2885.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu