### PR TITLE
Add missing release value call for opfunc_addition 

### DIFF
--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -145,6 +145,7 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
 
     if (ECMA_IS_VALUE_ERROR (str_right_value))
     {
+      ecma_free_value (right_value);
       ecma_deref_ecma_string (string1_p);
       return str_right_value;
     }

--- a/tests/jerry/fail/regression-test-issue-2894.js
+++ b/tests/jerry/fail/regression-test-issue-2894.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Array.prototype.unshift(Object(Symbol()));
+Array.prototype.reduce(function(p_0, p_1) { return p_0 + p_1}, "");

--- a/tests/jerry/fail/regression-test-issue-2897.js
+++ b/tests/jerry/fail/regression-test-issue-2897.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+object = { valueOf: function ( ) { return Symbol ( "foo" ) } };
+assert("" + object);


### PR DESCRIPTION
Right_value wasn't correctly freed in case of an error.
Fixes #2894
Fixes #2897

Co-authored-by: Tibor Dusnoki <tdusnoki@inf.u-szeged.hu>
JerryScript-DCO-1.0-Signed-off-by: Tibor Dusnoki tdusnoki@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu